### PR TITLE
Change type of reference densities (rhoVS and rhoLS) to Float64 

### DIFF
--- a/test/scripts/two_phase_gravity_segregation.jl
+++ b/test/scripts/two_phase_gravity_segregation.jl
@@ -20,10 +20,10 @@ function perform_test(nc = 100, tstep = repeat([0.02], 150))
     mu = 1e-3    # 1 cP
     pRef = 100*bar
     # Liquid
-    rhoLS = 1000
+    rhoLS = 1000.0
     cl = 1e-5/bar
     # Vapor
-    rhoVS = 100
+    rhoVS = 100.0
     cv = 1e-4/bar
 
 


### PR DESCRIPTION
Change type of reference densities (rhoVS and rhoLS) to Float64 for the two_phase_gravity_segregation.jl example This change stops the error from the type check in ```get_reference_densities``` in ```multiphase.jl```.

Without this fix, one would get the following error:
```
ERROR: LoadError: TypeError: in typeassert, expected Vector{Float64}, got a value of type Vector{Int64}
Stacktrace:
  [1] get_reference_densities(model::SimulationModel{Terv.DiscretizedDomain{MinimalTPFAGrid{Float64, Int64}}, ImmiscibleSystem, Terv.FullyImplicit, DefaultContext}, storage::TervStorage)
    @ Terv ~/projects/Terv.jl/src/applications/reservoir_simulator/multiphase.jl:273
  [2] convergence_criterion(model::SimulationModel{Terv.DiscretizedDomain{MinimalTPFAGrid{Float64, Int64}}, ImmiscibleSystem, Terv.FullyImplicit, DefaultContext}, storage::TervStorage, eq::ConservationLaw, r::Adjoint{Float64, Base.ReshapedArray{Float64, 2, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, Tuple{}}}; dt::Float64)
    @ Terv ~/projects/Terv.jl/src/applications/reservoir_simulator/multiphase.jl:260
  [3] check_convergence(lsys::LinearizedSystem{EquationMajorLayout}, eqs::NamedTuple{(:mass_conservation,), Tuple{ConservationLaw}}, storage::TervStorage, model::SimulationModel{Terv.DiscretizedDomain{MinimalTPFAGrid{Float64, Int64}}, ImmiscibleSystem, Terv.FullyImplicit, DefaultContext}; iteration::Int64, extra_out::Bool, tol::Nothing, offset::Int64, kwarg::Base.Iterators.Pairs{Symbol, Float64, Tuple{Symbol}, NamedTuple{(:dt,), Tuple{Float64}}})
    @ Terv ~/projects/Terv.jl/src/models.jl:352
  [4] check_convergence(storage::TervStorage, model::SimulationModel{Terv.DiscretizedDomain{MinimalTPFAGrid{Float64, Int64}}, ImmiscibleSystem, Terv.FullyImplicit, DefaultContext}; kwarg::Base.Iterators.Pairs{Symbol, Real, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iteration, :dt, :extra_out), Tuple{Int64, Float64, Bool}}})
    @ Terv ~/projects/Terv.jl/src/models.jl:332
  [5] perform_step!(storage::TervStorage, model::SimulationModel{Terv.DiscretizedDomain{MinimalTPFAGrid{Float64, Int64}}, ImmiscibleSystem, Terv.FullyImplicit, DefaultContext}, dt::Float64, forces::Nothing, config::Dict{Any, Any}; iteration::Int64)
    @ Terv ~/projects/Terv.jl/src/simulator.jl:65
  [6] perform_step!(simulator::Simulator, dt::Float64, forces::Nothing, config::Dict{Any, Any}; vararg::Base.Iterators.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:iteration,), Tuple{Int64}}})
    @ Terv ~/projects/Terv.jl/src/simulator.jl:46
  [7] solve_ministep(sim::Simulator, dt::Float64, forces::Nothing, maxIterations::Int64, linsolve::Nothing, cfg::Dict{Any, Any})
    @ Terv ~/projects/Terv.jl/src/simulator.jl:153
  [8] simulate(sim::Simulator, timesteps::Vector{Float64}; forces::Nothing, config::Dict{Any, Any}, kwarg::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Terv ~/projects/Terv.jl/src/simulator.jl:124
  [9] perform_test(nc::Int64, tstep::Vector{Float64})
    @ Main ~/projects/Terv.jl/test/scripts/two_phase_gravity_segregation.jl:52
 [10] perform_test()
    @ Main ~/projects/Terv.jl/test/scripts/two_phase_gravity_segregation.jl:15
 [11] top-level scope
    @ ~/projects/Terv.jl/test/scripts/two_phase_gravity_segregation.jl:62
in expression starting at /home/kjetil/projects/Terv.jl/test/scripts/two_phase_gravity_segregation.jl:62
```
