### PR TITLE
Fix scaling of lumped parameters for optimization

### DIFF
--- a/src/variables/vectorization.jl
+++ b/src/variables/vectorization.jl
@@ -51,7 +51,7 @@ function vectorize_variable!(V, state, k, info, F; config = nothing)
         for i in 1:maximum(lumping)
             # Take the first lumped value as they must be equal by assumption
             ix = findfirst(isequal(i), lumping)
-            V[offset+i] = state_val[ix]
+            V[offset+i] = F(state_val[ix])
         end
     end
 end


### PR DESCRIPTION
Scaling function was not applied when vectorizing lumped parameters for optimization. Only the inverse scaling function was applied during devectorization.