### PR TITLE
Adjoint fix

### DIFF
--- a/src/Jutul.jl
+++ b/src/Jutul.jl
@@ -44,7 +44,6 @@ module Jutul
     const var"@tic" = var"@timeit_debug"
     const JUTUL_OUTPUT_TYPE = OrderedDict{Symbol, Any}
     const JUTUL_IS_CI = get(ENV, "CI", "false") == "true"
-    const JUTUL_PROGRESS_BAR = get(ENV, "JUTUL_PROGRESS_BAR", "true") == "true" && !JUTUL_IS_CI
 
     timeit_debug_enabled() = false
 

--- a/src/Jutul.jl
+++ b/src/Jutul.jl
@@ -43,6 +43,8 @@ module Jutul
     # Shorted alias for @timeit_debug
     const var"@tic" = var"@timeit_debug"
     const JUTUL_OUTPUT_TYPE = OrderedDict{Symbol, Any}
+    const JUTUL_IS_CI = get(ENV, "CI", "false") == "true"
+    const JUTUL_PROGRESS_BAR = get(ENV, "JUTUL_PROGRESS_BAR", "true") == "true" && !JUTUL_IS_CI
 
     timeit_debug_enabled() = false
 

--- a/src/multimodel/gradients.jl
+++ b/src/multimodel/gradients.jl
@@ -19,7 +19,7 @@ function adjoint_model_copy(model::MultiModel; context = nothing)
     new_models = map(F, model.models)
     ctp = copy(model.cross_terms)
     if isnothing(context)
-        new_context = adjoint(DefaultContext())
+        new_context = adjoint(model.context)
     else
         new_context = adjoint(context)
     end

--- a/src/simulator/print.jl
+++ b/src/simulator/print.jl
@@ -31,7 +31,7 @@ function start_simulation_message(info_level, timesteps, config)
     if info_level >= 0
         jutul_message("Jutul", msg, color = :light_green)
     end
-    if JUTUL_PROGRESS_BAR && info_level == 0
+    if info_level == 0 && !JUTUL_IS_CI && get(ENV, "JUTUL_PROGRESS_BAR", "true") == "true"
         bg = config[:progress_glyphs]
         if bg isa Symbol
             if bg == :default
@@ -63,8 +63,10 @@ end
 
 function new_simulation_control_step_message(info_level, p, rec, elapsed, step_no, no_steps, dT, t_tot, start_date)
     if info_level == 0
-        msgvals = progress_showvalues(rec, elapsed, step_no, no_steps, dT, t_tot, start_date)
-        next!(p; showvalues = msgvals)
+        if !isnothing(p)
+            msgvals = progress_showvalues(rec, elapsed, step_no, no_steps, dT, t_tot, start_date)
+            next!(p; showvalues = msgvals)
+        end
     elseif info_level > 0
         r = rec.recorder
 
@@ -144,7 +146,7 @@ function final_simulation_message(simulator, p, rec, t_elapsed, reports, timeste
         if info_level == 0
             if aborted
                 cancel(p, "$start_str $final_message")
-            else
+            elseif !isnothing(p)
                 n = length(timesteps)
                 msgvals = progress_showvalues(rec, t_elapsed, n+1, n, 0.0, t_tot, start_date)
                 next!(p; showvalues = msgvals)

--- a/src/simulator/print.jl
+++ b/src/simulator/print.jl
@@ -31,7 +31,7 @@ function start_simulation_message(info_level, timesteps, config)
     if info_level >= 0
         jutul_message("Jutul", msg, color = :light_green)
     end
-    if info_level == 0
+    if JUTUL_PROGRESS_BAR && info_level == 0
         bg = config[:progress_glyphs]
         if bg isa Symbol
             if bg == :default
@@ -182,7 +182,17 @@ function final_simulation_message(simulator, p, rec, t_elapsed, reports, timeste
 end
 
 export jutul_message
-function jutul_message(prestr, substr = nothing; color = :light_blue, kwarg...)
+"""
+    jutul_message("Jutul", "Hello, world!", color = :light_blue)
+
+Print a line with a colored prefix. The prefix is colored with the `color`
+argument. The `fancy` argument controls whether the output is colored or not.
+"""
+function jutul_message(prestr, substr = nothing;
+        color = :light_blue,
+        fancy = !JUTUL_IS_CI,
+        kwarg...
+    )
     if isnothing(substr)
         fmt = "$prestr"
         substr = ""
@@ -190,8 +200,14 @@ function jutul_message(prestr, substr = nothing; color = :light_blue, kwarg...)
         fmt = "$prestr:"
         substr = " $substr"
     end
-    print(Crayon(foreground = color, bold = true; kwarg...), fmt)
-    println(Crayon(reset = true), substr)
+    if fancy
+        print(Crayon(foreground = color, bold = true; kwarg...), fmt)
+        println(Crayon(reset = true), substr)
+    else
+        # Skip colors on CI or when requested since colors do not render well in
+        # some Documenter exports and terminals.
+        println(fmt, substr)
+    end
 end
 
 function simulator_reports_per_step(simulator)


### PR DESCRIPTION
This pull request fixes a bug in adjoints for block-major matrices with cases that has more than one equation instance per cell entity (e.g., for thermal models). The changes are:

### Assertions and Index Adjustments:
* Introduced an assertion to ensure `source_entity_offset` is zero and adjusted the calculation of `partial_index` and `equation_index` in the `find_jac_position` function. (`src/equations.jl`)
* Added a return statement for `variable_offset` in the `align_to_jacobian!` function to ensure it is updated correctly. (`src/equations.jl`)

### Context Handling:
* Modified the `adjoint_model_copy` function to use the context from the model if the provided context is `nothing`. (`src/multimodel/gradients.jl`)