### PR TITLE
Add minimum timestep to simulator config

### DIFF
--- a/src/simulator/config.jl
+++ b/src/simulator/config.jl
@@ -15,6 +15,7 @@ Negative values disable output. The interpretation of this number is subject to 
     # Convergence tests
     add_option!(cfg, :max_timestep_cuts, 5, "Max time step cuts in a single mini step before termination of simulation.", types = Int, values = 0:10000)
     add_option!(cfg, :max_timestep, Inf, "Max time step length.", types = Float64)
+    add_option!(cfg, :min_timestep, 0.0, "Min time step length.", types = Float64)
     add_option!(cfg, :max_nonlinear_iterations, 15, "Max number of nonlinear iterations in a Newton solve before time-step is cut.", types = Int, values = 0:10000)
     add_option!(cfg, :min_nonlinear_iterations, 1, "Minimum number of nonlinear iterations in Newton solver.", description = "This number of Newtion iterations is always performed, even if all equations are converged.", types = Int, values = 0:10000)
     add_option!(cfg, :failure_cuts_timestep, false, "Cut the timestep if exceptions occur during step. If set to false, throw errors and terminate.", types = Bool)

--- a/src/simulator/timesteps.jl
+++ b/src/simulator/timesteps.jl
@@ -29,7 +29,7 @@ function pick_timestep(sim, config, dt_prev, dT, forces, reports, current_report
     if dt > half_remain && dt < remaining_time
         dt = half_remain
     end
-    dt = min(dt, config[:max_timestep])
+    dt = clamp(dt, config[:min_timestep], config[:max_timestep])
     if config[:info_level] > 1
         ratio = dt/dt_prev
         if ratio > 5
@@ -49,6 +49,9 @@ function pick_timestep(sim, config, dt_prev, dT, forces, reports, current_report
 end
 
 function cut_timestep(sim, config, dt, dT, forces, reports; step_index = NaN, cut_count = 0)
+    if isapprox(dt, config[:min_timestep])
+        return NaN
+    end
     for sel in config[:timestep_selectors]
         candidate = pick_cut_timestep(sel, sim, config, dt, dT, forces, reports, cut_count)
         dt = min(dt, candidate)


### PR DESCRIPTION
This pull request introduces a new configuration option for specifying a minimum timestep length and updates the timestep selection logic to respect this new configuration. The most important changes include adding the new configuration option and modifying the timestep selection and cutting functions to use this new option.

### Configuration Updates:
* [`src/simulator/config.jl`](diffhunk://#diff-f141eb094b8653cbe5b7ab4970cbac28095becfd7a822dc49798b6a1eccb50b6R18): Added a new configuration option `:min_timestep` to specify the minimum timestep length.

### Timestep Logic Updates:
* [`src/simulator/timesteps.jl`](diffhunk://#diff-28d3b1ba83e3515b30b3eab973779fbc2e9e6a3637303b0bf81b8ea3ae232b7dL32-R32): Updated the `pick_timestep` function to clamp the timestep between the new `min_timestep` and the existing `max_timestep` values.
* [`src/simulator/timesteps.jl`](diffhunk://#diff-28d3b1ba83e3515b30b3eab973779fbc2e9e6a3637303b0bf81b8ea3ae232b7dR52-R54): Modified the `cut_timestep` function to return `NaN` if the timestep is approximately equal to the `min_timestep`, preventing further cuts.