### PR TITLE
Convergence monitors

### DIFF
--- a/src/ConvergenceMonitors/ConvergenceMonitors.jl
+++ b/src/ConvergenceMonitors/ConvergenceMonitors.jl
@@ -1,0 +1,13 @@
+module ConvergenceMonitors
+
+    using Jutul
+
+    export ContractionFactorCuttingCriterion
+    export set_contraction_factor_cutting_criterion!
+
+    include("distance_functions.jl")
+    include("contraction_factors.jl")
+    include("cutting_criterions.jl")
+    include("utils.jl")
+
+end

--- a/src/ConvergenceMonitors/ConvergenceMonitors.jl
+++ b/src/ConvergenceMonitors/ConvergenceMonitors.jl
@@ -2,8 +2,8 @@ module ConvergenceMonitors
 
     using Jutul
 
-    export ContractionFactorCuttingCriterion
-    export set_contraction_factor_cutting_criterion!
+    export ConvergenceMonitorCuttingCriterion
+    export set_convergence_monitor_cutting_criterion!
 
     include("distance_functions.jl")
     include("contraction_factors.jl")

--- a/src/ConvergenceMonitors/ConvergenceMonitors.jl
+++ b/src/ConvergenceMonitors/ConvergenceMonitors.jl
@@ -4,10 +4,12 @@ module ConvergenceMonitors
 
     export ConvergenceMonitorCuttingCriterion
     export set_convergence_monitor_cutting_criterion!
+    export set_convergence_monitor_relaxation!
 
     include("distance_functions.jl")
     include("contraction_factors.jl")
     include("cutting_criterions.jl")
+    include("relaxation.jl")
     include("utils.jl")
 
 end

--- a/src/ConvergenceMonitors/contraction_factors.jl
+++ b/src/ConvergenceMonitors/contraction_factors.jl
@@ -24,6 +24,16 @@ function compute_contraction_factor(d, N)
 
 end
 
+"""
+    oscillation(contraction_factors, tol)
+
+Check if the contraction factors are oscillating. The function checks if the
+contraction factors are oscillating by checking if the last three contraction
+factors are below a user-defined tolerance defining "slow" convergece. The
+function returns true if the contraction factors are oscillating, and false
+otherwise. If less than three contraction factors are provided, the function
+returns false.
+"""
 function oscillation(contraction_factors, tol)
 
     θ = contraction_factors

--- a/src/ConvergenceMonitors/contraction_factors.jl
+++ b/src/ConvergenceMonitors/contraction_factors.jl
@@ -34,7 +34,7 @@ function returns true if the contraction factors are oscillating, and false
 otherwise. If less than three contraction factors are provided, the function
 returns false.
 """
-function oscillation(contraction_factors, tol)
+function oscillation(contraction_factors, tol = 1.0)
 
     θ = contraction_factors
     (length(θ) < 3) ? (return false) : nothing

--- a/src/ConvergenceMonitors/contraction_factors.jl
+++ b/src/ConvergenceMonitors/contraction_factors.jl
@@ -1,0 +1,42 @@
+"""
+    compute_contraction_factor(r, N)
+
+Compute contraction factor from a number of Newton iterate distances from
+convergence (defined with a user-prescribed distance metric). For more than two
+iterates, the contraction factor is estimated using least-squares assuming the
+iterates follow a geometric series: rₙ = Θⁿr₀. The function also computes the
+target contraction factor under this assumption assuming N iterations left.
+"""
+function compute_contraction_factor(d, N)
+
+    # Use distance from convergence + 1 to avoid division by small numbers
+    r = d .+ 1.0
+    # Number of iterates used to estimate contraction factor
+    n = size(r,1)-1
+    # Approximate log10 of contraction factor using least squares
+    num = sum(log.(r[2:end]./r[1]).*(1:n))
+    den = sum((1:n).^2)
+    θ = exp(num./den)
+    # Compute target contraction factor convergence in N iterations
+    θ_target = r[1].^(-1/N)
+    
+    return θ, θ_target
+
+end
+
+function oscillation(contraction_factors, tol)
+
+    θ = contraction_factors
+    (length(θ) < 3) ? (return false) : nothing
+
+    θ_1 = θ[end-2]
+    θ_2 = θ[end-1]
+    θ_3 = θ[end]
+
+    ok_1 = θ_1 .< tol
+    ok_2 = θ_2 .< tol
+    ok_3 = θ_3 .< tol
+
+    return .&(xor.(ok_1, ok_2), xor.(ok_2, ok_3))
+
+end

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -7,7 +7,7 @@
     # Number of iterations to use for computing contraction factor metrics
     memory = 1
     # Target number of nonlinear iterations for the timestep
-    target_iterations = 5
+    target_iterations = 8
     # Contraction factor parameters
     slow = 0.99
     fast = 0.1
@@ -48,7 +48,7 @@ function Jutul.cutting_criterion(cc::ConvergenceMonitorCuttingCriterion, sim, dt
     
     # Maximum number of iterations left if we should converge in
     # target_iterations iterations
-    N = max(max_iter - it + 1, 2)
+    N = max(cc.target_iterations - it + 1, 2)
     # First iterate number back in time to compute contraction factor
     it0 = max(it - cc.memory, 1)
 

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -26,7 +26,15 @@ config. The function also adjusts the maximum number of nonlinear iterations (to
 """
 function set_convergence_monitor_cutting_criterion!(config; max_nonlinear_iterations = 50, kwargs...)
 
-    cc = ConvergenceMonitorCuttingCriterion(; kwargs...)
+    target_iterations = 8
+    for sel in config[:timestep_selectors]
+        if sel isa IterationTimestepSelector
+            target_iterations = sel.target
+            break
+        end
+    end
+    cc = ConvergenceMonitorCuttingCriterion(; 
+    target_iterations = target_iterations, kwargs...)
     config[:cutting_criterion] = cc
     config[:max_nonlinear_iterations] = max_nonlinear_iterations
 
@@ -65,7 +73,7 @@ function Jutul.cutting_criterion(cc::ConvergenceMonitorCuttingCriterion, sim, dt
     cc.history[:contraction_factor][it] = Θ
     cc.history[:contraction_factor_target][it] = Θ_target
     # Check if the contraction factors are oscillating
-    oscillating_it = oscillation(cc.history[:contraction_factor][1:it], cc.slow)
+    oscillating_it = oscillation(cc.history[:contraction_factor][1:it])
     cc.history[:oscillation][it] = oscillating_it
     is_oscillating = any(cc.history[:oscillation][it0:it])
     

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -183,7 +183,7 @@ function print_convergence_status(cc::ConvergenceMonitorCuttingCriterion, it, it
         if θ < max(θ_target, θ_fast)
             inequality = "Θ = $θ ≤ max{$θ_target, $θ_fast} = max{Θ_target, θ_fast}"
         else
-            inequality = "Θ = $θ ≤ $θ_slow = Θ_slow"
+            inequality = "θ_target = $θ_target < Θ = $θ ≤ $θ_slow = Θ_slow"
         end
         sym = " →"
         color = :yellow

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -1,0 +1,155 @@
+@kwdef mutable struct ContractionFactorCuttingCriterion
+
+    # Function to compute the distance from convergence
+    distance_function = r -> compute_distance(r)
+    # Dict for storing contraction factor history
+    history = nothing
+    # Number of iterations to use for computing contraction factor metrics
+    memory = 1
+    # Target number of nonlinear iterations for the timestep
+    target_iterations = 5
+    # Contraction factor parameters
+    slow = 0.99
+    fast = 0.1
+    # Violation counter and limit for timestep cut
+    num_violations::Int     = 0
+    num_violations_cut::Int = 3
+
+end
+
+function set_contraction_factor_cutting_criterion!(config; max_nonlinear_iterations = 50, kwargs...)
+
+    cc = ContractionFactorCuttingCriterion(; kwargs...)
+    config[:cutting_criterion] = cc
+    config[:max_nonlinear_iterations] = max_nonlinear_iterations
+
+end
+
+function Jutul.cutting_criterion(cc::ContractionFactorCuttingCriterion, sim, dt, forces, it, max_iter, cfg, e, step_reports, relaxation)
+    
+    N = max(max_iter - it + 1, 2)
+    it0 = max(it - cc.memory, 1)
+
+    report = step_reports[end][:errors]
+    dist, = cc.distance_function(report)
+
+    (it == 1) ? reset!(cc, dist, max_iter) : nothing
+
+    # Store distance
+    cc.history[:distance][it] = dist
+
+    Θ, Θ_target = compute_contraction_factor(cc.history[:distance][it0:it], N)
+    cc.history[:contraction_factor][it] = Θ
+    cc.history[:contraction_factor_target][it] = Θ_target
+
+    oscillating_it = oscillation(cc.history[:contraction_factor][1:it], cc.slow)
+    cc.history[:oscillation][it] = oscillating_it
+    is_oscillating = any(cc.history[:oscillation][it0:it])
+    
+    good = all(Θ .<= max(Θ_target, cc.fast)) && !is_oscillating
+    ok = all(Θ .<= cc.slow)
+    bad = any(Θ .> cc.slow)
+
+    if good
+        # Convergence rate good, decrease number of violations
+        cc.num_violations -= 1
+        status = :good
+    elseif ok
+        # Convergence rate ok, keep number of violations
+        status = :ok
+    elseif bad
+        # Not converging, increase number of violations
+        cc.num_violations += 1
+        status = :bad
+    else
+        # First iteration
+        @assert it == 1
+        status = :none
+    end
+    cc.num_violations = max(0, cc.num_violations)
+    cc.history[:status][it] = status
+
+    early_cut = cc.num_violations > cc.num_violations_cut
+    step_reports[end][:cutting_criterion] = cc
+
+    if cfg[:info_level] >= 2
+        print_progress(cc, it, it0)
+    end
+
+    return (relaxation, early_cut)
+
+end
+
+function reset!(cc::ContractionFactorCuttingCriterion, template, max_iter)
+
+    cc.num_violations = 0
+    nc = max_iter + 1
+
+    history = Dict()
+    
+    history[:distance] = Array{typeof(template[1])}(undef, nc, length(template))
+    history[:contraction_factor] = Array{typeof(template[1])}(undef, nc, length(template))
+    history[:contraction_factor_target] = Array{typeof(template[1])}(undef, nc, length(template))
+    history[:status] = Array{Symbol}(undef, nc, length(template))
+    history[:oscillation] = Array{Bool}(undef, nc, length(template))
+
+    history[:contraction_factor][1] = NaN
+    history[:contraction_factor_target][1] = NaN
+    history[:status][1] = :none
+    history[:oscillation][1] = false
+    
+    cc.history = history
+
+end
+
+function print_progress(cc::ContractionFactorCuttingCriterion, it, it0)
+
+    round_local(x) = round(x; digits = 2)
+
+    θ = cc.history[:contraction_factor][it]
+    θ_target = cc.history[:contraction_factor_target][it]
+    θ_slow = cc.slow
+    θ_fast = cc.fast
+    status = cc.history[:status][it]
+    oscillation = any(cc.history[:oscillation][it0:it])
+
+    θ = round_local(θ)
+    θ_target = round_local(θ_target)
+    θ_slow = round_local(θ_slow)
+    θ_fast = round_local(θ_fast)
+    
+    if status == :none
+        inequality, sym, color, reason = "", "", :white, ""
+    elseif status == :good
+        inequality = "Θ = $θ ≤ max{$θ_target, $θ_fast} = max{Θ_target, θ_fast}"
+        sym = " ↓"
+        color = :green
+    elseif status == :ok
+        if θ < max(θ_target, θ_fast)
+            inequality = "Θ = $θ ≤ max{$θ_target, $θ_fast} = max{Θ_target, θ_fast}"
+        else
+            inequality = "Θ = $θ ≤ $θ_slow = Θ_slow"
+        end
+        sym = " →"
+        color = :yellow
+    elseif status == :bad
+        inequality = "Θ = $θ > $θ_slow = Θ_slow"
+        color = :red
+        sym = " ↑"
+    else
+        error("Unknown status: $status")
+    end
+
+    if status != :none        
+        reason = "\n\t\t Reason: " * inequality
+        reason *= oscillation ? " (oscillation)" : ""
+    end
+
+    msg = "(It. $(it-1)): "
+    msg *= "status = $(cc.history[:status][it]), "
+    msg *= "violations = $(cc.num_violations)" * sym
+    msg *= reason
+    msg *= "."
+    Jutul.jutul_message("\tConvergence monitor", msg, color = color)
+
+end

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -1,4 +1,4 @@
-@kwdef mutable struct ContractionFactorCuttingCriterion
+@kwdef mutable struct ConvergenceMonitorCuttingCriterion
 
     # Function to compute the distance from convergence
     distance_function = r -> compute_distance(r)
@@ -17,15 +17,15 @@
 
 end
 
-function set_contraction_factor_cutting_criterion!(config; max_nonlinear_iterations = 50, kwargs...)
+function set_convergence_monitor_cutting_criterion!(config; max_nonlinear_iterations = 50, kwargs...)
 
-    cc = ContractionFactorCuttingCriterion(; kwargs...)
+    cc = ConvergenceMonitorCuttingCriterion(; kwargs...)
     config[:cutting_criterion] = cc
     config[:max_nonlinear_iterations] = max_nonlinear_iterations
 
 end
 
-function Jutul.cutting_criterion(cc::ContractionFactorCuttingCriterion, sim, dt, forces, it, max_iter, cfg, e, step_reports, relaxation)
+function Jutul.cutting_criterion(cc::ConvergenceMonitorCuttingCriterion, sim, dt, forces, it, max_iter, cfg, e, step_reports, relaxation)
     
     N = max(max_iter - it + 1, 2)
     it0 = max(it - cc.memory, 1)
@@ -70,8 +70,8 @@ function Jutul.cutting_criterion(cc::ContractionFactorCuttingCriterion, sim, dt,
     cc.history[:status][it] = status
 
     early_cut = cc.num_violations > cc.num_violations_cut
-    cc_report = make_report(Θ, Θ_target, is_oscillating, status)
-    step_reports[end][:cutting_criterion] = cc_report
+    cm_report = make_report(Θ, Θ_target, is_oscillating, status)
+    step_reports[end][:convergence_monitor] = cm_report
 
     if cfg[:info_level] >= 2
         print_progress(cc, it, it0)
@@ -81,7 +81,7 @@ function Jutul.cutting_criterion(cc::ContractionFactorCuttingCriterion, sim, dt,
 
 end
 
-function reset!(cc::ContractionFactorCuttingCriterion, template, max_iter)
+function reset!(cc::ConvergenceMonitorCuttingCriterion, template, max_iter)
 
     cc.num_violations = 0
     nc = max_iter + 1
@@ -114,7 +114,7 @@ function make_report(θ, θ_target, oscillation, status)
 
 end
 
-function print_progress(cc::ContractionFactorCuttingCriterion, it, it0)
+function print_progress(cc::ConvergenceMonitorCuttingCriterion, it, it0)
 
     round_local(x) = round(x; digits = 2)
 

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -70,7 +70,8 @@ function Jutul.cutting_criterion(cc::ContractionFactorCuttingCriterion, sim, dt,
     cc.history[:status][it] = status
 
     early_cut = cc.num_violations > cc.num_violations_cut
-    step_reports[end][:cutting_criterion] = cc
+    cc_report = make_report(Θ, Θ_target, is_oscillating, status)
+    step_reports[end][:cutting_criterion] = cc_report
 
     if cfg[:info_level] >= 2
         print_progress(cc, it, it0)
@@ -99,6 +100,17 @@ function reset!(cc::ContractionFactorCuttingCriterion, template, max_iter)
     history[:oscillation][1] = false
     
     cc.history = history
+
+end
+
+function make_report(θ, θ_target, oscillation, status)
+
+    report = Dict()
+    report[:contraction_factor] = θ
+    report[:contraction_factor_target] = θ_target
+    report[:oscillation] = oscillation
+    report[:status] = status
+    return report
 
 end
 

--- a/src/ConvergenceMonitors/distance_functions.jl
+++ b/src/ConvergenceMonitors/distance_functions.jl
@@ -1,3 +1,10 @@
+"""
+    compute_distance(report; distance_function = r -> scaled_residual_norm(r), mapping = v -> maximum(v))
+
+Compute distance from convergence using a user-defined distance function, and
+optionally apply a mapping to the distance. The function returns the distance
+and the names of equation residual norms used in the distance computation.
+"""
 function compute_distance(report; 
     distance_function = r -> scaled_residual_norm(r),
     mapping = v -> maximum(v)
@@ -12,6 +19,12 @@ function compute_distance(report;
 
 end
 
+"""
+    scaled_residual_norm(report)
+
+Compute distance to convergence as the residual norm of the equations scaled by
+their respective tolerances.
+"""
 function scaled_residual_norm(report)
 
     residuals = get_multimodel_residuals(report)
@@ -22,15 +35,13 @@ function scaled_residual_norm(report)
 
 end
 
-function log_scaled_residual_norm(report)
+"""
+    nonconverged_equations(report)
 
-    distance, names = scaled_residual_norm(report)
-    distance = log10.(distance .+ 1.0)
-
-    return distance, names
-
-end
-
+Compute distance to convergence as non-converged equations, e.g., 1.0 for
+non-converged and 0.0 for converged. The final distance is typically taken as
+the sum of the output from this function.
+"""
 function nonconverged_equations(report)
 
     values, names = scaled_residual_norm(report)

--- a/src/ConvergenceMonitors/distance_functions.jl
+++ b/src/ConvergenceMonitors/distance_functions.jl
@@ -1,0 +1,41 @@
+function compute_distance(report; 
+    distance_function = r -> scaled_residual_norm(r),
+    mapping = v -> maximum(v)
+    )
+    
+    # Compute distance using distance function
+    distance, names = distance_function(report)
+    # Apply transformation
+    distance = mapping(distance)
+
+    return distance, names
+
+end
+
+function scaled_residual_norm(report)
+
+    residuals = get_multimodel_residuals(report)
+    values, names = flatten_dict(residuals)
+    distance = max.(values .- 1.0, 0.0)
+
+    return distance, names
+
+end
+
+function log_scaled_residual_norm(report)
+
+    distance, names = scaled_residual_norm(report)
+    distance = log10.(distance .+ 1.0)
+
+    return distance, names
+
+end
+
+function nonconverged_equations(report)
+
+    values, names = scaled_residual_norm(report)
+    distance = (values .> 0.0) .+ 0.0
+
+    return distance, names
+
+end

--- a/src/ConvergenceMonitors/relaxation.jl
+++ b/src/ConvergenceMonitors/relaxation.jl
@@ -62,11 +62,16 @@ function Jutul.select_nonlinear_relaxation_model(model, rel_type::ConvergenceMon
         report = reports[end-1]
         @assert haskey(report, :convergence_monitor)
         status = report[:convergence_monitor][:status]
+        oscillating = report[:convergence_monitor][:oscillation]
 
-        if status == :bad
+        if status == :bad || oscillating
             ω = ω - dw_decrease
-        elseif status == :good
+        elseif status ∈ [:good, :ok]
             ω = ω + dw_increase
+        elseif status == :none
+            # No change
+        else
+            error("Unknown status: $status")
         end
         ω = clamp(ω, w_min, w_max)
 

--- a/src/ConvergenceMonitors/relaxation.jl
+++ b/src/ConvergenceMonitors/relaxation.jl
@@ -1,0 +1,52 @@
+struct ConvergenceMonitorRelaxation <: Jutul.NonLinearRelaxation
+    w_min::Float64
+    w_max::Float64
+    dw_decrease::Float64
+    dw_increase::Float64
+end
+
+function ConvergenceMonitorRelaxation(; w_min = 0.1, dw = 0.2, dw_increase = nothing, dw_decrease = nothing, w_max = 1.0)
+    if isnothing(dw_increase)
+        dw_increase = dw/2
+    end
+    if isnothing(dw_decrease)
+        dw_decrease = dw
+    end
+    return ConvergenceMonitorRelaxation(w_min, w_max, dw_decrease, dw_increase)
+end
+
+function set_convergence_monitor_relaxation!(config; 
+    max_nonlinear_iterations = 50,
+    convergence_monitor_args = NamedTuple(),
+    relaxation_args...
+    )
+    
+    set_convergence_monitor_cutting_criterion!(config; 
+    max_nonlinear_iterations = max_nonlinear_iterations, 
+    convergence_monitor_args...)
+
+    rel = ConvergenceMonitorRelaxation(; relaxation_args...)
+    config[:relaxation] = rel
+
+end
+
+function Jutul.select_nonlinear_relaxation_model(model, rel_type::ConvergenceMonitorRelaxation, reports, ω)
+    if length(reports) > 1
+        (; dw_decrease, dw_increase, w_max, w_min) = rel_type
+        
+        report = reports[end-1]
+        @assert haskey(report, :convergence_monitor)
+        status = report[:convergence_monitor][:status]
+
+        if status == :bad
+            ω = ω - dw_decrease
+        elseif status == :good
+            ω = ω + dw_increase
+        end
+        ω = clamp(ω, w_min, w_max)
+
+        println("Relaxation: ", ω)
+
+    end
+    return ω
+end

--- a/src/ConvergenceMonitors/relaxation.jl
+++ b/src/ConvergenceMonitors/relaxation.jl
@@ -5,6 +5,14 @@ struct ConvergenceMonitorRelaxation <: Jutul.NonLinearRelaxation
     dw_increase::Float64
 end
 
+"""
+    ConvergenceMonitorRelaxation(; w_min = 0.1, dw = 0.2, dw_increase = nothing, dw_decrease = nothing, w_max = 1.0)
+
+Relaxation strategy based on convergence monitoring. Requires that the
+ simulation has been configured with a `ConvergenceMonitorCuttingCriterion` so
+that the convergence status is available in the reports. See corresponding
+iplementation of `select_nonlinear_relaxation_model` below for details.
+"""
 function ConvergenceMonitorRelaxation(; w_min = 0.1, dw = 0.2, dw_increase = nothing, dw_decrease = nothing, w_max = 1.0)
     if isnothing(dw_increase)
         dw_increase = dw/2
@@ -15,6 +23,13 @@ function ConvergenceMonitorRelaxation(; w_min = 0.1, dw = 0.2, dw_increase = not
     return ConvergenceMonitorRelaxation(w_min, w_max, dw_decrease, dw_increase)
 end
 
+"""
+    set_convergence_monitor_relaxation!(config; max_nonlinear_iterations = 50, convergence_monitor_args = NamedTuple(), relaxation_args...)
+
+Utility for setting `ConvergenceMonitorRelaxation` to the simulator config. This
+function also sets the a `ConvergenceMonitorCuttingCriterion` to the config --
+see `set_convergence_monitor_cutting_criterion!`.
+"""
 function set_convergence_monitor_relaxation!(config; 
     max_nonlinear_iterations = 50,
     convergence_monitor_args = NamedTuple(),
@@ -30,7 +45,17 @@ function set_convergence_monitor_relaxation!(config;
 
 end
 
+"""
+    Jutul.select_nonlinear_relaxation_model(model, rel_type::ConvergenceMonitorRelaxation, reports, ω)
+
+Relaxation strategy based on convergence monitoring. The relaxation factor is
+decreased if the convergence status is "bad", and increased if the status is
+"good", determined by contraction factors computed from distance to convergence
+(in a user-defined metric) between consecutive iterates. These are computed
+during the cutting criterion check and stored in the reports.
+"""
 function Jutul.select_nonlinear_relaxation_model(model, rel_type::ConvergenceMonitorRelaxation, reports, ω)
+
     if length(reports) > 1
         (; dw_decrease, dw_increase, w_max, w_min) = rel_type
         
@@ -45,8 +70,8 @@ function Jutul.select_nonlinear_relaxation_model(model, rel_type::ConvergenceMon
         end
         ω = clamp(ω, w_min, w_max)
 
-        println("Relaxation: ", ω)
-
     end
+
     return ω
+
 end

--- a/src/ConvergenceMonitors/utils.jl
+++ b/src/ConvergenceMonitors/utils.jl
@@ -1,0 +1,78 @@
+function get_multimodel_residuals(report)
+
+    models = keys(report)
+
+    residuals = Dict()
+
+    for model in models
+        rsd = get_model_residuals(report[model])
+        residuals[model] = rsd
+    end
+
+    return residuals
+
+end
+
+function get_model_residuals(report)
+
+    residuals = Dict()
+
+    for eq_report in report
+
+        equation = eq_report[:name]
+        criterions = eq_report[:criterions]
+        tolerances = eq_report[:tolerances]
+        residual_norms = keys(criterions)
+
+        equation_residuals = Dict()
+    
+        for res_norm in residual_norms
+
+            rsd = criterions[res_norm].errors
+            tol = tolerances[res_norm]
+            nms = criterions[res_norm].names
+            for i in eachindex(rsd)
+                α, r = nms[i], rsd[i]
+                α = process_name(α)
+                if !haskey(equation_residuals, α)
+                    equation_residuals[α] = Dict()
+                end
+                equation_residuals[α][res_norm] = r/tol
+            end
+
+        end
+
+        residuals[equation] = equation_residuals
+    
+    end
+
+    return residuals
+
+end
+
+function process_name(name)
+
+    name = String(name)
+    name = replace(name, " " => "_", "(" => "", ")" => "")
+    name = Symbol(name)
+
+end
+
+function flatten_dict(input_dict::Dict, separator::String = ".", trail = [])
+    values = []
+    names = []
+
+    for (key, value) in input_dict
+        current_trail = vcat(trail, string(key))
+        if value isa Dict
+            sub_values, sub_names = flatten_dict(value, separator, current_trail)
+            append!(values, sub_values)
+            append!(names, sub_names)
+        else
+            push!(values, value)
+            push!(names, join(current_trail, separator))
+        end
+    end
+
+    return values, names
+end

--- a/src/ConvergenceMonitors/utils.jl
+++ b/src/ConvergenceMonitors/utils.jl
@@ -1,3 +1,14 @@
+# TODO: dispatch on model type (scalar model/multimodel)
+
+"""
+    get_multimodel_residuals(report)
+
+Get all residual norms for all equations of all models from a nonlinear
+iteration report, scaled by their respective toelrances. The function returns a
+dict of dicts with the residual norms for each equation on the form
+
+    residuals[model][equation_type][equation][norm] = res/tol
+"""
 function get_multimodel_residuals(report)
 
     models = keys(report)
@@ -13,6 +24,16 @@ function get_multimodel_residuals(report)
 
 end
 
+"""
+    get_model_residuals(report)
+
+
+Get all residual norms for all equations of a model from a nonlinear
+iteration report, scaled by their respective toelrances. The function returns a
+dict of dicts with the residual norms for each equation on the form
+
+    residuals[equation_type][equation][norm] = res/tol
+"""
 function get_model_residuals(report)
 
     residuals = Dict()
@@ -50,6 +71,11 @@ function get_model_residuals(report)
 
 end
 
+"""
+    process_name(name)
+
+Process a names to be suibale as dictionary keys.
+"""
 function process_name(name)
 
     name = String(name)
@@ -58,6 +84,13 @@ function process_name(name)
 
 end
 
+"""
+    flatten_dict(input_dict::Dict, separator::String = ".", trail = [])
+
+Flatten a dict of dicts into a vector of values and a vector of names. The names
+are on the format `"key1<separator>key2<separator>key3"` and the values are the
+corresponding values in the dict.
+"""
 function flatten_dict(input_dict::Dict, separator::String = ".", trail = [])
     values = []
     names = []

--- a/src/ConvergenceMonitors/utils.jl
+++ b/src/ConvergenceMonitors/utils.jl
@@ -77,8 +77,8 @@ end
 Process a names to be suibale as dictionary keys.
 """
 function process_name(name)
-
-    name = String(name)
+    
+    name = string(name)
     name = replace(name, " " => "_", "(" => "", ")" => "")
     name = Symbol(name)
 

--- a/src/Jutul.jl
+++ b/src/Jutul.jl
@@ -116,4 +116,9 @@ module Jutul
     using .LBFGS
     import .LBFGS: unit_box_bfgs
 
+    # Convergence monitors
+    include("ConvergenceMonitors/ConvergenceMonitors.jl")
+    import Jutul.ConvergenceMonitors: ContractionFactorCuttingCriterion
+    import Jutul.ConvergenceMonitors: set_contraction_factor_cutting_criterion!
+
 end # module

--- a/src/Jutul.jl
+++ b/src/Jutul.jl
@@ -118,7 +118,7 @@ module Jutul
 
     # Convergence monitors
     include("ConvergenceMonitors/ConvergenceMonitors.jl")
-    import Jutul.ConvergenceMonitors: ContractionFactorCuttingCriterion
-    import Jutul.ConvergenceMonitors: set_contraction_factor_cutting_criterion!
+    import Jutul.ConvergenceMonitors: ConvergenceMonitorCuttingCriterion
+    import Jutul.ConvergenceMonitors: set_convergence_monitor_cutting_criterion!
 
 end # module

--- a/src/Jutul.jl
+++ b/src/Jutul.jl
@@ -120,5 +120,6 @@ module Jutul
     include("ConvergenceMonitors/ConvergenceMonitors.jl")
     import Jutul.ConvergenceMonitors: ConvergenceMonitorCuttingCriterion
     import Jutul.ConvergenceMonitors: set_convergence_monitor_cutting_criterion!
+    import Jutul.ConvergenceMonitors: set_convergence_monitor_relaxation!
 
 end # module


### PR DESCRIPTION
This pull request introduces a new module `ConvergenceMonitors`, which includes various utilities and functions for monitoring convergence in simulations.

### New Module:
* [`src/ConvergenceMonitors/ConvergenceMonitors.jl`](diffhunk://#diff-f046087cd7a50b7bb6bef7008d0273060ed8860554e0ec68fb2b39b2db5628c1R1-R15): Created the `ConvergenceMonitors` module and exported key functions and structures.

### Contraction Factors:
* [`src/ConvergenceMonitors/contraction_factors.jl`](diffhunk://#diff-d35dc475b3db831d2ff84891eeebfc64176db8ff8c8ef75463881514f8c949a4R1-R52): Added functions to compute contraction factors and check for oscillations in convergence.

### Cutting Criterion:
* [`src/ConvergenceMonitors/cutting_criterions.jl`](diffhunk://#diff-48a66ec6eb0242c285e77a74069f304b6396489d20120c8158525e3228e6c695R1-R218): Introduced the `ConvergenceMonitorCuttingCriterion` structure and related functions to manage and evaluate cutting criteria.

### Distance Functions:
* [`src/ConvergenceMonitors/distance_functions.jl`](diffhunk://#diff-79a8c24ff07b3687ff3ecae40713ca7be90d9d41e22682c9a16aa49753e45b5eR1-R52): Implemented functions to compute distances from convergence using various metrics.

### Relaxation Strategy:
* [`src/ConvergenceMonitors/relaxation.jl`](diffhunk://#diff-d8f10230d5b47a0f37a8eea8ab8a3ae94572e17efa8a640bbeaffbf7de97b10cR1-R82): Added the `ConvergenceMonitorRelaxation` structure and functions to adjust relaxation based on convergence monitoring.

### Utility Functions:
* [`src/ConvergenceMonitors/utils.jl`](diffhunk://#diff-477870d80650b25e5a58a36650c1f874b2060fa5de09e62b1549a355a159b45dR1-R111): Added utility functions for handling residuals.

### Integration with Jutul:
* [`src/Jutul.jl`](diffhunk://#diff-0601af922d0d54d3506f0f43fe99716a7eef0e6bb46af7fff209fb807cd3f824R119-R124): Integrated the `ConvergenceMonitors` module into the main `Jutul` module.