### PR TITLE
Add state0 variables to the optimization interface

### DIFF
--- a/src/multimodel/gradients.jl
+++ b/src/multimodel/gradients.jl
@@ -136,7 +136,7 @@ function rescale_sensitivities!(dG, model::MultiModel, parameter_map)
 end
 
 function optimization_config(model::MultiModel, param, active = nothing; kwarg...)
-    out = Dict{Symbol, Any}()
+    out = Dict{Symbol, OptimizationConfig}()
     for k in submodels_symbols(model)
         m = model[k]
         if isnothing(active) || !haskey(active, k)

--- a/src/multimodel/vectorization.jl
+++ b/src/multimodel/vectorization.jl
@@ -31,3 +31,15 @@ function devectorize_variables!(state_or_prm, model::MultiModel, V, type_or_map 
     end
     return state_or_prm
 end
+
+function devectorize_state_and_parameters!(state, parameters, model::MultiModel, V, mapper, config)
+    for (k, submodel) in pairs(model.models)
+        if isnothing(config)
+            c = nothing
+        else
+            c = config[k]
+        end
+        devectorize_state_and_parameters!(state[k], parameters[k], submodel, V, mapper[k], c)
+    end
+    return (state, parameters)
+end

--- a/src/simulator/optimization.jl
+++ b/src/simulator/optimization.jl
@@ -72,12 +72,13 @@ function setup_parameter_optimization(case::JutulCase, G, opt_cfg = optimization
     end
     sort_variables!(model, :parameters)
 
-    include_state0 = opt_cfg.include_state0
-    variables = parameters
+    include_state0 = state0_active(opt_cfg)
     if include_state0
-        variables = merge(variables, state0)
+        merge_state_with_parameters(model, state0, parameters)
+        variables = state0
         type = :all
     else
+        variables = parameters
         type = :parameters
     end
 
@@ -283,6 +284,14 @@ Base.iterate(opt_cfg::OptimizationConfig, state) = iterate(opt_cfg.config, state
 Base.getindex(opt_cfg::OptimizationConfig, key) = opt_cfg.config[key]
 Base.pairs(opt_cfg::OptimizationConfig) = pairs(opt_cfg.config)
 Base.setindex!(opt_cfg::OptimizationConfig, value, key) = opt_cfg.config[key] = value
+
+function state0_active(configs::Dict{Symbol, OptimizationConfig})
+    return any(state0_active, values(configs))
+end
+
+function state0_active(cfg::OptimizationConfig)
+    return cfg.include_state0
+end
 
 function optimization_config(model::SimulationModel, param, active = parameter_targets(model);
         rel_min = nothing,

--- a/src/variables/vectorization.jl
+++ b/src/variables/vectorization.jl
@@ -124,9 +124,9 @@ function devectorize_variable!(state, V, k, info, F_inv; config = c)
     end
 end
 
-function devectorize_state_and_parameters!(state, parameters, model, x, mapper, config)
+function devectorize_state_and_parameters!(state, parameters, model, V, mapper, config)
     state_and_parameters = merge(state, parameters)
-    devectorize_variables!(state_and_parameters, model, x, mapper; config=config)
+    devectorize_variables!(state_and_parameters, model, V, mapper; config=config)
     for k in keys(mapper)
         if haskey(state, k)
             state[k] = state_and_parameters[k]
@@ -134,6 +134,7 @@ function devectorize_state_and_parameters!(state, parameters, model, x, mapper, 
             parameters[k] = state_and_parameters[k]
         end
     end
+    return (state, parameters)
 end
 
 function get_lumping(config::Nothing)


### PR DESCRIPTION
This PR adds the initial simulation variables (state0) to the optimization interface of Jutul, so that they can be included in the gradient-based optimization along with the model parameters.