### PR TITLE
Shift coordinates sent to plotting so that origin is where it should be

### DIFF
--- a/src/meshes/cart.jl
+++ b/src/meshes/cart.jl
@@ -490,6 +490,12 @@ function triangulate_mesh(m::CartesianMesh; outer = false)
             end
         end
     end
+
+    o = hcat(m.origin...)
+    for i = 1:length(pts)
+        pts[i] .+= o
+    end
+
     pts = plot_flatten_helper(pts)
     tri = plot_flatten_helper(tri)
 


### PR DESCRIPTION
Modify `triangulate_mesh` function in `src/meshes/cart.jl` so that prescribed origin of the grid coincides with the one plotted.

* [`src/meshes/cart.jl`](diffhunk://#diff-d1e17811b4a9a59ccf89c605659fbf7489296039408db688728c29d0bdaab599R493-R498): Updated the `triangulate_mesh` function to offset mesh points by the origin (`m.origin`) to ensure correct positioning.