### PR TITLE
Convergence monitor improvement

### DIFF
--- a/src/ConvergenceMonitors/contraction_factors.jl
+++ b/src/ConvergenceMonitors/contraction_factors.jl
@@ -50,3 +50,14 @@ function oscillation(contraction_factors, tol = 1.0)
     return .&(xor.(ok_1, ok_2), xor.(ok_2, ok_3))
 
 end
+
+function iterations_left(contraction_factor, dist)
+
+    # Compute number of iterations left if we should converge in target_iterations
+    # iterations
+    θ = contraction_factor
+    N = ceil(-log(dist)/log(θ))
+    N = (N > 0) ? Int64(N) : 0
+    return N
+
+end

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -69,18 +69,20 @@ function Jutul.cutting_criterion(cc::ConvergenceMonitorCuttingCriterion, sim, dt
     cc.history[:distance][it] = dist
 
     # Compute contraction factor and update history
-    Θ, Θ_target = compute_contraction_factor(cc.history[:distance][it0:it], N)
-    cc.history[:contraction_factor][it] = Θ
-    cc.history[:contraction_factor_target][it] = Θ_target
+    θ, θ_target = compute_contraction_factor(cc.history[:distance][it0:it], N)
+    its_left = iterations_left(θ, dist)
+    cc.history[:contraction_factor][it] = θ
+    cc.history[:contraction_factor_target][it] = θ_target
+    cc.history[:iterations_left][it] = its_left
     # Check if the contraction factors are oscillating
     oscillating_it = oscillation(cc.history[:contraction_factor][1:it])
     cc.history[:oscillation][it] = oscillating_it
     is_oscillating = any(cc.history[:oscillation][it0:it])
     
     # Determine if current rate of convergence is adequate
-    good = all(Θ .<= max(Θ_target, cc.fast)) && !is_oscillating
-    ok = all(Θ .<= cc.slow)
-    bad = any(Θ .> cc.slow)
+    good = all(θ .<= max(θ_target, cc.fast)) && !is_oscillating
+    ok = all(θ .<= cc.slow) && its_left <= cc.target_iterations
+    bad = any(θ .> cc.slow) || its_left > cc.target_iterations
 
     if good
         # Convergence rate good, decrease number of violations
@@ -107,7 +109,7 @@ function Jutul.cutting_criterion(cc::ConvergenceMonitorCuttingCriterion, sim, dt
     early_cut = cc.num_violations > cc.num_violations_cut
     
     # Generate convergence monitor report and store in step report
-    cm_report = make_report(Θ, Θ_target, is_oscillating, status)
+    cm_report = make_report(θ, θ_target, is_oscillating, status)
     step_reports[end][:convergence_monitor] = cm_report
 
     # Print status of convergence monitoring
@@ -132,11 +134,13 @@ function reset!(cc::ConvergenceMonitorCuttingCriterion, template, max_iter)
     history[:distance] = Array{typeof(template[1])}(undef, nc, length(template))
     history[:contraction_factor] = Array{typeof(template[1])}(undef, nc, length(template))
     history[:contraction_factor_target] = Array{typeof(template[1])}(undef, nc, length(template))
-    history[:status] = Array{Symbol}(undef, nc, length(template))
-    history[:oscillation] = Array{Bool}(undef, nc, length(template))
+    history[:iterations_left] = Vector{Union{Int64, Float64}}(undef, nc)
+    history[:status] = Vector{Symbol}(undef, nc)
+    history[:oscillation] = Vector{Bool}(undef, nc)
 
     history[:contraction_factor][1] = NaN
     history[:contraction_factor_target][1] = NaN
+    history[:iterations_left][1] = NaN
     history[:status][1] = :none
     history[:oscillation][1] = false
     
@@ -171,6 +175,7 @@ function print_convergence_status(cc::ConvergenceMonitorCuttingCriterion, it, it
 
     θ = cc.history[:contraction_factor][it]
     θ_target = cc.history[:contraction_factor_target][it]
+    its_left = cc.history[:iterations_left][it]
     θ_slow = cc.slow
     θ_fast = cc.fast
     status = cc.history[:status][it]
@@ -196,7 +201,12 @@ function print_convergence_status(cc::ConvergenceMonitorCuttingCriterion, it, it
         sym = " →"
         color = :yellow
     elseif status == :bad
-        inequality = "Θ = $θ > $θ_slow = Θ_slow"
+        its_target = cc.target_iterations
+        if its_left > its_target
+            inequality = "Iterations left = $its_left > $its_target = target iterations"
+        else
+            inequality = "Θ = $θ > $θ_slow = Θ_slow"
+        end
         color = :red
         sym = " ↑"
     else

--- a/src/ConvergenceMonitors/cutting_criterions.jl
+++ b/src/ConvergenceMonitors/cutting_criterions.jl
@@ -8,6 +8,8 @@
     memory = 1
     # Target number of nonlinear iterations for the timestep
     target_iterations = 8
+    # Max number of estimated iterations left for iterate to be classified as ok
+    max_iterations_left = 2*target_iterations
     # Contraction factor parameters
     slow = 0.99
     fast = 0.1
@@ -81,8 +83,8 @@ function Jutul.cutting_criterion(cc::ConvergenceMonitorCuttingCriterion, sim, dt
     
     # Determine if current rate of convergence is adequate
     good = all(θ .<= max(θ_target, cc.fast)) && !is_oscillating
-    ok = all(θ .<= cc.slow) && its_left <= cc.target_iterations
-    bad = any(θ .> cc.slow) || its_left > cc.target_iterations
+    ok = all(θ .<= cc.slow) && its_left <= cc.max_iterations_left
+    bad = any(θ .> cc.slow) || its_left > cc.max_iterations_left
 
     if good
         # Convergence rate good, decrease number of violations
@@ -201,9 +203,9 @@ function print_convergence_status(cc::ConvergenceMonitorCuttingCriterion, it, it
         sym = " →"
         color = :yellow
     elseif status == :bad
-        its_target = cc.target_iterations
-        if its_left > its_target
-            inequality = "Iterations left = $its_left > $its_target = target iterations"
+        max_its = cc.max_iterations_left
+        if its_left > max_its
+            inequality = "Iterations left = $its_left > $max_its = upper limit"
         else
             inequality = "Θ = $θ > $θ_slow = Θ_slow"
         end


### PR DESCRIPTION
Incorporate new metric, `iterations_left`, which estimates the remaining iterations required for convergence given current convergence rate. An iterate is classified as "bad" if iterations left is above a predefined threshold even if the iterate was a contraction.