### PR TITLE
Bug fix in expand_perm and improvement to grid_dims_ijk

### DIFF
--- a/src/discretization/finite-volume.jl
+++ b/src/discretization/finite-volume.jl
@@ -174,7 +174,7 @@ function expand_perm(K, ::Val{2})
     elseif n == 3
         K_xx = K[1]
         K_xy = K[2]
-        K_yy = K[2]
+        K_yy = K[3]
     else
         error("Permeability for two-dimensional grids must have 1/2/3 entries per cell, had $n")
     end
@@ -201,7 +201,7 @@ function expand_perm(K, ::Val{3})
         # First row
         K_xx = K[1]
         K_xy = K[2]
-        K_yz = K[3]
+        K_xz = K[3]
         # Second row excluding symmetry
         K_yy = K[4]
         K_yz = K[5]

--- a/src/meshes/mrst.jl
+++ b/src/meshes/mrst.jl
@@ -34,7 +34,16 @@ function MRSTWrapMesh(G, N = nothing)
 end
 
 function grid_dims_ijk(g::MRSTWrapMesh)
-    return tuple(Int.(g.data.cartDims)...)
+    cart = Int.(vec(g.data.cartDims)) 
+    if length(cart) == 3
+        return (cart[1], cart[2], cart[3])
+    elseif length(cart) == 2
+        return (cart[1], cart[2], 1)
+    elseif length(cart) == 1
+        return (cart[1], 1, 1)
+    else
+        error("Unsupported cartDims length = $(length(cart))")
+    end 
 end
 
 function cell_dims(g::MRSTWrapMesh, pos::Integer)


### PR DESCRIPTION
Hi,

This pull request includes:

1. Bug fix – Corrected permeability component assignment in expand_perm(K, ::Val{3}) and expand_perm(K, ::Val{2}).

1. Improvement – Updated grid_dims_ijk(g::MRSTWrapMesh) to consistently output three numbers for 1D, 2D, and 3D grids (previously only worked for 3D).

Thanks,
Shaowen