### PR TITLE
Change adjoint step info to use time at new timestep

### DIFF
--- a/src/ad/gradients.jl
+++ b/src/ad/gradients.jl
@@ -989,8 +989,8 @@ from this function will be passed to objective functions as `step_info`. This
 function is a `Dict` with the following fields:
 
 # Fields
-- `:time` - The time at the start of the step. To get time at the end of the
-  step, use `step_info[:time] + step_info[:dt]`
+- `:time` - The time at the end of the step. To get time at the start of the
+  step, use `step_info[:time] - step_info[:dt]`
 - `:dt` - The time step size for this step.
 - `:step` - The step number, starting at 1. Not that this is the report step,
   and multiple `step_info` entries could have the same step if substeps are
@@ -1001,7 +1001,7 @@ function is a `Dict` with the following fields:
 - `:substep_global` - The global substep number, starting at 1 and will not
   reset between global steps.
 - `:Nsubstep_global` - The total number of substeps in the simulation.
-- `:total_time` - The total time of the simulation (i.e. dt + time at the final
+- `:total_time` - The total time of the simulation (i.e. time at the final
   step and substep)
 """
 function optimization_step_info(step::Int, time::Real, dt::Real;
@@ -1030,7 +1030,7 @@ end
 
 function optimization_step_info(step::Int, dts::Vector; kwarg...)
     t = 0.0
-    for i in 1:(step-1)
+    for i in 1:(step)
         t += dts[i]
     end
     return optimization_step_info(step, t, dts[step]; Nstep = length(dts), total_time = sum(dts), kwarg...)

--- a/src/core_types/core_types.jl
+++ b/src/core_types/core_types.jl
@@ -1426,6 +1426,7 @@ function AdjointPackedResult(states, dt::Vector{Float64}, forces, step_index)
     prev_ministep = 0
     step_infos = missing
     for (i, dt_i) in enumerate(dt)
+        time += dt_i
         step_ix = step_index[i]
         if step_ix != prev_ministep
             ministep_ix = 1
@@ -1445,7 +1446,6 @@ function AdjointPackedResult(states, dt::Vector{Float64}, forces, step_index)
         else
             push!(step_infos, step_info)
         end
-        time += dt_i
     end
     if !ismissing(forces)
         forces = map(i -> forces_for_timestep(nothing, forces, dt, i), step_index)


### PR DESCRIPTION
Change the definition of `time` in the adjoint code to mean time at end of a timestep. This is consistent with the definition in the forward simulation.