### PR TITLE
Improve progress recorder API

### DIFF
--- a/src/ad/AdjointsDI/adjoints.jl
+++ b/src/ad/AdjointsDI/adjoints.jl
@@ -138,7 +138,7 @@ function update_sensitivities_generic!(∇G, X, H, i, G, adjoint_storage, packed
     report_step = step_info[:step]
     for skey in [:backward, :forward]
         s = adjoint_storage[skey]
-        Jutul.reset!(Jutul.progress_recorder(s), step = report_step, time = current_time)
+        Jutul.recorder_reset!(Jutul.progress_recorder(s), step = report_step, time = current_time)
     end
 
     λ = Jutul.next_lagrange_multiplier!(adjoint_storage, i, G, state0, state, state_next, packed_steps)

--- a/src/ad/gradients.jl
+++ b/src/ad/gradients.jl
@@ -456,7 +456,7 @@ function update_sensitivities!(∇G, i, G, adjoint_storage, state0, state, state
     forces = packed_step.forces
     for skey in [:backward, :forward, :parameter]
         s = adjoint_storage[skey]
-        reset!(progress_recorder(s), step = report_step, time = current_time)
+        recorder_reset!(progress_recorder(s), step = report_step, time = current_time)
     end
     λ = next_lagrange_multiplier!(adjoint_storage, i, G, state0, state, state_next, packed_steps)
     # λ, t, dt, forces

--- a/src/simulator/recorder.jl
+++ b/src/simulator/recorder.jl
@@ -4,38 +4,57 @@ step(r) = r.recorder.step
 substep(r) = r.subrecorder.step
 
 # Progress recorder stuff
-function nextstep_global!(r::ProgressRecorder, dT, prev_success = !isnan(r.recorder.dt))
-    g = r.recorder
-    l = r.subrecorder
-    g.iteration = l.iterations
-    # A bit dicey, just need to get this working
-    g.failed += l.failed
-    nextstep!(g, dT, prev_success)
-    reset!(r.subrecorder)
-end
-
-function nextstep_local!(r::ProgressRecorder, dT, prev_success = !isnan(r.local_recorder.dt))
-    nextstep!(r.subrecorder, dT, prev_success)
-end
-
-function next_iteration!(rec, report)
-    if haskey(report, :update_time)
-        rec.subrecorder.iteration += 1
+function recorder_start_step!(rec::ProgressRecorder, dt, level::Symbol)
+    level == :local || level == :global || error("level must be :local or :global")
+    if level == :local
+        rec.subrecorder.dt = dt
+    else # global
+        rec.recorder.dt = dt
     end
 end
 
-function nextstep!(l::SolveRecorder, dT, success)
-    # Update time
-    if success
-        l.step += 1
-        l.time += l.dt
-    else
-        l.failed += l.iteration
+function recorder_log_step!(rec::ProgressRecorder, success, level::Symbol)
+    level == :local || level == :global || error("level must be :local or :global")
+    l = rec.subrecorder
+    g = rec.recorder
+
+    function update!(solver_rec, success)
+        if success
+            solver_rec.step += 1
+            solver_rec.time += solver_rec.dt
+        else
+            solver_rec.failed += solver_rec.iteration
+        end
+        solver_rec.iterations += solver_rec.iteration
+        solver_rec.iteration = 0
     end
-    l.dt = dT
-    # Update iterations
-    l.iterations += l.iteration
-    l.iteration = 0
+
+    if level == :local
+        update!(l, success)
+    else # global
+        g.iteration = l.iterations
+        g.failed += l.failed
+        update!(g, success)
+        reset!(l)
+    end
+end
+
+function recorder_current_time(rec::ProgressRecorder, level::Symbol)
+    level == :local || level == :global || error("level must be :local or :global")
+    if level == :local
+        return rec.subrecorder.time
+    else # global
+        return rec.recorder.time + rec.subrecorder.time
+    end
+end
+
+function recorder_increment_iteration!(rec::ProgressRecorder, report, level::Symbol)
+    level == :local || level == :global || error("level must be :local or :global")
+    if level == :local
+        if haskey(report, :update_time)
+            rec.subrecorder.iteration += 1
+        end
+    end
 end
 
 function reset!(r::SolveRecorder, dt = NaN; step = 1, iterations = 0, iteration = 0, time = 0.0)
@@ -63,8 +82,3 @@ function reset!(target::ProgressRecorder, source::ProgressRecorder)
     reset!(target.recorder, source.recorder)
     reset!(target.subrecorder, source.recorder)
 end
-
-function current_time(r::ProgressRecorder)
-    return r.recorder.time + r.subrecorder.time
-end
-

--- a/src/simulator/recorder.jl
+++ b/src/simulator/recorder.jl
@@ -35,7 +35,7 @@ function recorder_log_step!(rec::ProgressRecorder, success, level::Symbol)
         g.iteration = l.iterations
         g.failed += l.failed
         update!(g, success)
-        reset!(l)
+        recorder_reset!(l)
     end
 end
 
@@ -57,7 +57,7 @@ function recorder_increment_iteration!(rec::ProgressRecorder, report, level::Sym
     end
 end
 
-function reset!(r::SolveRecorder, dt = NaN; step = 1, iterations = 0, iteration = 0, time = 0.0)
+function recorder_reset!(r::SolveRecorder, dt = NaN; step = 1, iterations = 0, iteration = 0, time = 0.0)
     r.step = step
     r.iterations = iterations
     r.time = time
@@ -65,7 +65,7 @@ function reset!(r::SolveRecorder, dt = NaN; step = 1, iterations = 0, iteration 
     r.dt = dt
 end
 
-function reset!(target::SolveRecorder, source::SolveRecorder)
+function recorder_reset!(target::SolveRecorder, source::SolveRecorder)
     target.step = source.step
     target.iterations = source.iterations
     target.time = source.time
@@ -73,12 +73,22 @@ function reset!(target::SolveRecorder, source::SolveRecorder)
     target.dt = source.dt
 end
 
-function reset!(r::ProgressRecorder, dt = NaN; kwarg...)
-    reset!(r.recorder, dt; kwarg...)
-    reset!(r.subrecorder, 0.0)
+function recorder_reset!(r::ProgressRecorder, dt = NaN; kwarg...)
+    recorder_reset!(r.recorder, dt; kwarg...)
+    recorder_reset!(r.subrecorder, 0.0)
 end
 
-function reset!(target::ProgressRecorder, source::ProgressRecorder)
-    reset!(target.recorder, source.recorder)
-    reset!(target.subrecorder, source.recorder)
+function recorder_reset!(target::ProgressRecorder, source::ProgressRecorder)
+    recorder_reset!(target.recorder, source.recorder)
+    recorder_reset!(target.subrecorder, source.recorder)
 end
+
+@deprecate reset!(r::SolveRecorder, dt = NaN;
+    step = 1,
+    iterations = 0,
+    iteration = 0,
+    time = 0.0) recorder_reset!(r, dt; step, iterations, iteration, time)
+
+@deprecate reset!(target::SolveRecorder, source::SolveRecorder) recorder_reset!(targe, source)
+@deprecate reset!(r::ProgressRecorder, dt = NaN; kwarg...) recorder_reset!(r, dt; kwarg...)
+@deprecate reset!(target::ProgressRecorder, source::ProgressRecorder) recorder_reset!(target, source)

--- a/src/simulator/simulator.jl
+++ b/src/simulator/simulator.jl
@@ -201,7 +201,7 @@ function simulate!(sim::JutulSimulator, timesteps::AbstractVector;
     for step_no = first_step:no_steps
         dT = timesteps[step_no]
         forces_step = forces_for_timestep(sim, forces, timesteps, step_no, per_step = forces_per_step)
-        nextstep_global!(rec, dT)
+        recorder_start_step!(rec, dT, :global)
         new_simulation_control_step_message(info_level, p, rec, t_elapsed, step_no, no_steps, dT, t_tot, start_date)
         if config[:output_substates]
             substates = JUTUL_OUTPUT_TYPE[]
@@ -219,6 +219,7 @@ function simulate!(sim::JutulSimulator, timesteps::AbstractVector;
         subrep = JUTUL_OUTPUT_TYPE()
         subrep[:ministeps] = rep
         subrep[:total_time] = t_step
+        recorder_log_step!(rec, step_done, :global)
         if step_done
             lastrep = rep[end]
             if get(lastrep, :stopnow, false)
@@ -284,11 +285,13 @@ function solve_timestep!(sim, dT, forces, max_its, config;
     while !done
         # Make sure that we hit the endpoint in case timestep selection is too optimistic.
         dt = min(dt, dT - t_local)
+        recorder_start_step!(rec, dt, :local)
         # Attempt to solve current step
         @tic "solve" ok, s = solve_ministep(sim, dt, forces, max_its, config; kwarg...)
+        recorder_log_step!(rec, ok, :local)
+
         # We store the report even if it is a failure.
         push!(ministep_reports, s)
-        nextstep_local!(rec, dt, ok)
         n_so_far = length(ministep_reports)
         if ok
             if 2 > info_level > 1
@@ -357,7 +360,7 @@ function perform_step!(storage, model, dt, forces, config;
     end
     # Update the properties and equations
     rec = storage.recorder
-    time = rec.recorder.time + dt
+    time = recorder_current_time(rec, :global) + dt
     prep, prep_storage = get_prepare_step_handler(storage)
     # Apply a pre-step if it exists
     if ismissing(prep)
@@ -517,7 +520,7 @@ function solve_ministep(sim, dt, forces, max_iter, cfg;
     report = JUTUL_OUTPUT_TYPE()
     report[:dt] = dt
     step_reports = JUTUL_OUTPUT_TYPE[]
-    cur_time = current_time(rec)
+    cur_time = recorder_current_time(rec, :global)
     t_prepare = @elapsed if prepare
         update_before_step!(sim, dt, forces, time = cur_time, recorder = rec, update_explicit = update_explicit)
     end
@@ -539,7 +542,7 @@ function solve_ministep(sim, dt, forces, max_iter, cfg;
             end
             break
         end
-        next_iteration!(rec, step_report)
+        recorder_increment_iteration!(rec, step_report, :local)
         if done
             break
         end

--- a/src/simulator/simulator.jl
+++ b/src/simulator/simulator.jl
@@ -159,7 +159,7 @@ function simulate!(sim::JutulSimulator, timesteps::AbstractVector;
     )
     rec = progress_recorder(sim)
     # Reset recorder just in case since we are starting a new simulation
-    reset!(rec)
+    recorder_reset!(rec)
     forces, forces_per_step = preprocess_forces(sim, forces)
     start_timestamp = now()
     if isnothing(config)


### PR DESCRIPTION
Splitting up some of the functions makes the API easier to use. This also fixes some subtle off-by-one errors for the `dt` and `time` values in the simulation, that could lead to problems in the case that, e.g., `force` is explicitly dependent on `time`.