### PR TITLE
Fix bug in format of time stamp for printing simulation result

### DIFF
--- a/src/simulator/utils.jl
+++ b/src/simulator/utils.jl
@@ -126,7 +126,7 @@ function Base.show(io::IO, ::MIME"text/plain", sr::SimResult)
 end
 
 function print_sim_result_timing(io, sr::SimResult)
-    fmt = raw"u. dd Y H:mm"
+    fmt = raw"u. dd Y HH:MM"
     if length(sr.reports) == 0
         t = 0.0
     else


### PR DESCRIPTION
The `mm` was giving the month in the minute position, e.g., `xx:09` for September