### PR TITLE
Find enclosing cell improvement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Jutul"
 uuid = "2b460a1a-8a2b-45b2-b125-b5c536396eb9"
 authors = ["Olav Møyner <olav.moyner@gmail.com>"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"

--- a/src/meshes/trajectories.jl
+++ b/src/meshes/trajectories.jl
@@ -27,10 +27,18 @@ of cells are treated more rigorously when picking exactly what cells are cut by
 a trajectory, but this requires that the boundary normals are oriented outwards,
 which is currently not the case for all meshes from downstream packages.
 
+`atol` is the tolerance used when checking if points are inside the bounding
+box.
+
 `limit_box` speeds up the search by limiting the search to the minimal bounding
 box that contains both the trajectory and the mesh. This can be turned off by
 passing `false`. There should be no difference in the cells tagged by changing
 this option.
+
+`cells` can be used to limit the search to a subset of cells in the mesh. By
+default all cells are used. If `limit_box` is true, the function searches among
+the cells in intersect(cells, cells inside bounding box).
+
 """
 function find_enclosing_cells(G, traj;
         geometry = missing,
@@ -38,6 +46,7 @@ function find_enclosing_cells(G, traj;
         use_boundary = false,
         atol = 0.01,
         limit_box = true,
+        cells = 1:number_of_cells(G),
         extra_out = false
     )
     G = UnstructuredMesh(G)
@@ -96,9 +105,9 @@ function find_enclosing_cells(G, traj;
         inside_bb(x) = point_in_bounding_box(x, low_bb, high_bb, atol = atol)
         pts = filter(inside_bb, pts)
         # Find cells via their nodes - if any node is inside BB we consider the cell
-        cells = cells_inside_bounding_box(G, low_bb, high_bb, atol = atol)
-    else
-        cells = 1:number_of_cells(G)
+        cells_bb = cells_inside_bounding_box(G, low_bb, high_bb, atol = atol)
+        cells = intersect(cells_bb, cells)
+        println("Limiting search to $(length(cells)) cells inside bounding box.")
     end
     # Start search near middle of trajectory
     mean_pt = mean(pts)

--- a/src/meshes/trajectories.jl
+++ b/src/meshes/trajectories.jl
@@ -107,7 +107,6 @@ function find_enclosing_cells(G, traj;
         # Find cells via their nodes - if any node is inside BB we consider the cell
         cells_bb = cells_inside_bounding_box(G, low_bb, high_bb, atol = atol)
         cells = intersect(cells_bb, cells)
-        println("Limiting search to $(length(cells)) cells inside bounding box.")
     end
     # Start search near middle of trajectory
     mean_pt = mean(pts)


### PR DESCRIPTION
Add extra keyword argument `cells` to `find_enclosing_cells`, enabling searching only a subset of the mesh.