### PR TITLE
Embedded mesh update

### DIFF
--- a/src/meshes/EmbeddedMeshes/finite-volume.jl
+++ b/src/meshes/EmbeddedMeshes/finite-volume.jl
@@ -41,7 +41,12 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
     vdim = Val(dim)
     cc = zeros(eltype(cell_centroids), dim)
     fc = zeros(eltype(face_centroids), dim)
+    ix_cells = Set(mesh.intersection_cells)
+    N = get_neighborship(mesh)
     for cell = 1:nc
+        if cell in ix_cells
+            continue
+        end
         cn = cell_normal(mesh, cell)
         for fpos = facepos[cell]:(facepos[cell+1]-1)
             face = faces[fpos]
@@ -54,6 +59,21 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
             T = Jutul.half_face_trans(A, K, C, Nn)
             T = abs(T)
             T_hf[fpos] = T
+        end
+    end
+    # For intersection cells, copy the half-face trans from the neighbor on each shared face
+    for ix_cell in mesh.intersection_cells
+        for fpos = facepos[ix_cell]:(facepos[ix_cell+1]-1)
+            face = faces[fpos]
+            l, r = N[:, face]
+            neighbor = (l == ix_cell) ? r : l
+            # Find the neighbor's half-face position for this face
+            for npos = facepos[neighbor]:(facepos[neighbor+1]-1)
+                if faces[npos] == face
+                    T_hf[fpos] = T_hf[npos]
+                    break
+                end
+            end
         end
     end
     return T_hf

--- a/src/meshes/EmbeddedMeshes/finite-volume.jl
+++ b/src/meshes/EmbeddedMeshes/finite-volume.jl
@@ -64,20 +64,23 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
         end
     end
     # For intersection cells, copy the half-face trans from the neighbor on each shared face
-    for ix_cell in mesh.intersection_cells
-        for fpos = facepos[ix_cell]:(facepos[ix_cell+1]-1)
-            face = faces[fpos]
-            l, r = N[:, face]
-            neighbor = (l == ix_cell) ? r : l
-            # Find the neighbor's half-face position for this face
-            for npos = facepos[neighbor]:(facepos[neighbor+1]-1)
-                if faces[npos] == face
-                    T_hf[fpos] = T_hf[npos].*d_hf[npos]./(aperture[ix_cell]/2)
-                    break
+    if !isempty(mesh.intersection_cells)
+        for ix_cell in mesh.intersection_cells
+            for fpos = facepos[ix_cell]:(facepos[ix_cell+1]-1)
+                face = faces[fpos]
+                l, r = N[:, face]
+                neighbor = (l == ix_cell) ? r : l
+                # Find the neighbor's half-face position for this face
+                for npos = facepos[neighbor]:(facepos[neighbor+1]-1)
+                    if faces[npos] == face
+                        T_hf[fpos] = T_hf[npos].*d_hf[npos]./(aperture[ix_cell]/2)
+                        break
+                    end
                 end
             end
         end
     end
+
     return T_hf
 end
 

--- a/src/meshes/EmbeddedMeshes/finite-volume.jl
+++ b/src/meshes/EmbeddedMeshes/finite-volume.jl
@@ -9,7 +9,7 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
     dim = size(cell_centroids, 1)
 
     T_hf = zeros(eltype(face_areas), length(faces))
-    d_hf = zeros(eltype(face_areas), length(faces))
+    Nn_hf = Vector{SVector{dim, Float64}}(undef, length(faces))
     nc = length(facepos)-1
     if isa(perm, AbstractFloat)
         perm = repeat([perm], 1, nc)
@@ -60,7 +60,7 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
             T = Jutul.half_face_trans(A, K, C, Nn)
             T = abs(T)
             T_hf[fpos] = T
-            d_hf[fpos] = norm(C, 2)
+            Nn_hf[fpos] = Nn
         end
     end
     # For intersection cells, copy the half-face trans from the neighbor on each shared face
@@ -73,7 +73,11 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
                 # Find the neighbor's half-face position for this face
                 for npos = facepos[neighbor]:(facepos[neighbor+1]-1)
                     if faces[npos] == face
-                        T_hf[fpos] = T_hf[npos].*d_hf[npos]./(aperture[ix_cell]/2)
+                        A = face_areas[face]
+                        Nn = Nn_hf[npos]
+                        C = Nn.*aperture[neighbor]/2
+                        K = Jutul.expand_perm(perm[:, neighbor], vdim)
+                        T_hf[fpos] = Jutul.half_face_trans(A, K, C, Nn)
                         break
                     end
                 end

--- a/src/meshes/EmbeddedMeshes/finite-volume.jl
+++ b/src/meshes/EmbeddedMeshes/finite-volume.jl
@@ -4,11 +4,12 @@
 Compute half-face transmissibilities for finite volume discretization in
 embedded meshes.
 """
-function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_centroids, face_areas, perm, faces, facepos)
+function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_centroids, face_areas, perm, aperture, faces, facepos)
     nf = length(face_areas)
     dim = size(cell_centroids, 1)
 
     T_hf = zeros(eltype(face_areas), length(faces))
+    d_hf = zeros(eltype(face_areas), length(faces))
     nc = length(facepos)-1
     if isa(perm, AbstractFloat)
         perm = repeat([perm], 1, nc)
@@ -59,6 +60,7 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
             T = Jutul.half_face_trans(A, K, C, Nn)
             T = abs(T)
             T_hf[fpos] = T
+            d_hf[fpos] = norm(C, 2)
         end
     end
     # For intersection cells, copy the half-face trans from the neighbor on each shared face
@@ -70,7 +72,7 @@ function Jutul.compute_half_face_trans(mesh::EmbeddedMesh, cell_centroids, face_
             # Find the neighbor's half-face position for this face
             for npos = facepos[neighbor]:(facepos[neighbor+1]-1)
                 if faces[npos] == face
-                    T_hf[fpos] = T_hf[npos]
+                    T_hf[fpos] = T_hf[npos].*d_hf[npos]./(aperture[ix_cell]/2)
                     break
                 end
             end
@@ -154,11 +156,13 @@ function half_face_normal(mesh::EmbeddedMesh, face, cell, cn)
 
 end
 
-function compute_face_trans_dfm(T_hf, N, intersections)
+function compute_face_trans_dfm(T_hf, N, intersections, star_delta)
     T = compute_face_trans(T_hf, N)
-    T_ix, ix_faces = compute_intersection_trans_dfm(T_hf, N, intersections)
-    for (f, T_val) in zip(ix_faces, T_ix)
-        T[f] = T_val
+    if star_delta
+        T_ix, ix_faces = compute_intersection_trans_dfm(T_hf, N, intersections)
+        for (f, T_val) in zip(ix_faces, T_ix)
+            T[f] = T_val
+        end
     end
     return T
 end

--- a/src/meshes/EmbeddedMeshes/geometry.jl
+++ b/src/meshes/EmbeddedMeshes/geometry.jl
@@ -13,6 +13,12 @@ Jutul.face_normal(mesh::EmbeddedMesh, f, e::Jutul.BoundaryFaces) = Jutul.face_no
 
 function Jutul.compute_centroid_and_measure(mesh::EmbeddedMesh, ::Jutul.Cells, i)
 
+    if i ∈ mesh.intersection_cells
+        faces = mesh.unstructured_mesh.faces.cells_to_faces[i]
+        centroid, area =  Jutul.compute_centroid_and_measure(mesh, Jutul.Faces(), faces[1])
+        return (centroid, area)
+    end
+
     umesh = mesh.unstructured_mesh
     pts = umesh.node_points
     T = eltype(pts)

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -15,6 +15,7 @@ interconnected faces.
 """
 struct EmbeddedMesh <: Jutul.FiniteVolumeMesh
     unstructured_mesh::UnstructuredMesh
+    parent_faces::Vector{Int}
     intersection_neighbors::Vector{Vector{Int}}
     intersection_faces::Vector{Vector{Int}}
     intersection_cells::Vector{Int}
@@ -45,7 +46,7 @@ function EmbeddedMesh(mesh::UnstructuredMesh, faces; intersection_strategy = :st
         faces;
         intersection_strategy = intersection_strategy
     )
-    return EmbeddedMesh(embedded_mesh, intersection_neighbors, intersection_faces, intersection_cells)
+    return EmbeddedMesh(embedded_mesh, faces, intersection_neighbors, intersection_faces, intersection_cells)
 end
 
 function Jutul.UnstructuredMesh(mesh::EmbeddedMesh)

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -7,11 +7,13 @@ interconnected faces.
 
 # Fields
 - `unstructured_mesh::UnstructuredMesh`: The underlying unstructured mesh representation
-- `intersections::Vector{Vector{Int}}`: Indices of embedded mesh cells that are part of intersections
+- `intersections::Vector{Vector{Int}}`: Backward-compatible alias for `intersection_neighbors`
+- `intersection_neighbors::Vector{Vector{Int}}`: Embedded mesh cells grouped per intersection
 """
 struct EmbeddedMesh <: Jutul.FiniteVolumeMesh
     unstructured_mesh::UnstructuredMesh
     intersections::Vector{Vector{Int}}
+    intersection_neighbors::Vector{Vector{Int}}
 end
 
 """
@@ -23,16 +25,27 @@ Construct an embedded mesh from selected faces of an unstructured mesh.
 - `mesh::UnstructuredMesh`: Parent mesh containing the faces
 - `faces`: Collection of face indices to include in the embedded mesh
 
+# Keyword arguments
+- `include_intersection_connections::Bool = false`: If `true`, intersections
+    with three or more faces are split into pairwise internal connections. If
+    `false` (default), intersection edges are kept disconnected in the
+    neighborship and stored in `intersections`.
+
 # Returns
-- `EmbeddedMesh`: Embedded mesh made up of the specified faces. Instances of
-  three or more faces intersecting at an edge is split into pairwise
-  connections.
+- `EmbeddedMesh`: Embedded mesh made up of the specified faces.
 
 """
-function EmbeddedMesh(mesh::UnstructuredMesh, faces)
-    embedded_mesh, intersections = make_mesh_from_faces(mesh, faces)
-    return EmbeddedMesh(embedded_mesh, intersections)
+function EmbeddedMesh(mesh::UnstructuredMesh, faces; include_intersection_connections = false)
+    embedded_mesh, intersections = make_mesh_from_faces(
+        mesh,
+        faces;
+        include_intersection_connections = include_intersection_connections
+    )
+    return EmbeddedMesh(embedded_mesh, intersections, intersections)
 end
+
+EmbeddedMesh(mesh::UnstructuredMesh, intersections::Vector{Vector{Int}}) =
+    EmbeddedMesh(mesh, intersections, intersections)
 
 function Jutul.UnstructuredMesh(mesh::EmbeddedMesh)
     return mesh.unstructured_mesh
@@ -43,7 +56,7 @@ end
 
 Helper for EmbeddedMesh constructor.
 """
-function make_mesh_from_faces(mesh, faces)
+function make_mesh_from_faces(mesh, faces; include_intersection_connections = false)
 
     # Make edges
     face_edges, num_edges_per_face, face_edge_signs, neighbors = get_face_edges(mesh, faces)
@@ -80,8 +93,15 @@ function make_mesh_from_faces(mesh, faces)
     neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges, 
     face_edge_signs, face_edge_pos, intersection_faces = 
     split_intersections(
-        neighbors, face_edges, face_edge_signs, face_edge_pos, length(faces), 
-        edge_nodes, num_nodes_per_edge)
+        neighbors,
+        face_edges,
+        face_edge_signs,
+        face_edge_pos,
+        length(faces),
+        edge_nodes,
+        num_nodes_per_edge;
+        include_intersection_connections = include_intersection_connections
+    )
     edge_node_pos = cumsum([1; num_nodes_per_edge])
 
     # Fix orientation of edges
@@ -144,7 +164,16 @@ function get_edge_nodes(mesh, edges)
 end
 
 
-function split_intersections(neighbors, face_edges, face_edge_signs, face_edge_pos, num_faces, edge_nodes, num_nodes_per_edge)
+function split_intersections(
+    neighbors,
+    face_edges,
+    face_edge_signs,
+    face_edge_pos,
+    num_faces,
+    edge_nodes,
+    num_nodes_per_edge;
+    include_intersection_connections = false
+)
 
     new_neighbors = Vector{Vector{Int}}()
     new_edge_nodes = Vector{Int}()
@@ -166,30 +195,42 @@ function split_intersections(neighbors, face_edges, face_edge_signs, face_edge_p
         current_edge_node_idx += n_nodes
 
         if length(faces) > 2
-            # Intersection: create pairwise connections
-            # Connect every pair (f_i, f_j)
-            for i in 1:length(faces)
-                for j in (i+1):length(faces)
-                    f1 = faces[i]
-                    f2 = faces[j]
-                    
-                    push!(new_neighbors, [f1, f2])
+            if include_intersection_connections
+                # Intersection: create pairwise internal connections.
+                for i in 1:length(faces)
+                    for j in (i+1):length(faces)
+                        f1 = faces[i]
+                        f2 = faces[j]
+
+                        push!(new_neighbors, [f1, f2])
+                        append!(new_edge_nodes, nodes)
+                        push!(new_num_nodes_per_edge, n_nodes)
+
+                        new_edge_idx = length(new_neighbors)
+
+                        if !haskey(replacements[old_edge_idx], f1)
+                            replacements[old_edge_idx][f1] = Int[]
+                        end
+                        push!(replacements[old_edge_idx][f1], new_edge_idx)
+
+                        if !haskey(replacements[old_edge_idx], f2)
+                            replacements[old_edge_idx][f2] = Int[]
+                        end
+                        push!(replacements[old_edge_idx][f2], new_edge_idx)
+                    end
+                end
+            else
+                # Intersection: duplicate as boundary edge per face.
+                for f in faces
+                    push!(new_neighbors, [f])
                     append!(new_edge_nodes, nodes)
                     push!(new_num_nodes_per_edge, n_nodes)
-                    
+
                     new_edge_idx = length(new_neighbors)
-                    
-                    # Register replacement for f1
-                    if !haskey(replacements[old_edge_idx], f1)
-                        replacements[old_edge_idx][f1] = Int[]
+                    if !haskey(replacements[old_edge_idx], f)
+                        replacements[old_edge_idx][f] = Int[]
                     end
-                    push!(replacements[old_edge_idx][f1], new_edge_idx)
-                    
-                    # Register replacement for f2
-                    if !haskey(replacements[old_edge_idx], f2)
-                        replacements[old_edge_idx][f2] = Int[]
-                    end
-                    push!(replacements[old_edge_idx][f2], new_edge_idx)
+                    push!(replacements[old_edge_idx][f], new_edge_idx)
                 end
             end
             # Store faces that are part of intersection

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -8,14 +8,15 @@ interconnected faces.
 # Fields
 - `unstructured_mesh::UnstructuredMesh`: The underlying unstructured mesh representation
 - `intersection_neighbors::Vector{Vector{Int}}`: Embedded mesh cells grouped per intersection
-- `intersection_boundary_faces::Vector{Vector{Int}}`: Boundary-local face indices per intersection,
-  aligned with `intersection_neighbors`
+- `intersection_faces::Vector{Vector{Int}}`: Face indices per intersection, aligned with
+  `intersection_neighbors`. For `:remove`, these are boundary face indices; for `:star_delta`
+  and `:keep`, these are internal face indices.
 - `intersection_cells::Vector{Int}`: Embedded mesh cell indices created for kept intersections
 """
 struct EmbeddedMesh <: Jutul.FiniteVolumeMesh
     unstructured_mesh::UnstructuredMesh
     intersection_neighbors::Vector{Vector{Int}}
-    intersection_boundary_faces::Vector{Vector{Int}}
+    intersection_faces::Vector{Vector{Int}}
     intersection_cells::Vector{Int}
 end
 
@@ -39,12 +40,12 @@ Construct an embedded mesh from selected faces of an unstructured mesh.
 
 """
 function EmbeddedMesh(mesh::UnstructuredMesh, faces; intersection_strategy = :star_delta)
-    embedded_mesh, intersection_neighbors, intersection_boundary_faces, intersection_cells = make_mesh_from_faces(
+    embedded_mesh, intersection_neighbors, intersection_faces, intersection_cells = make_mesh_from_faces(
         mesh,
         faces;
         intersection_strategy = intersection_strategy
     )
-    return EmbeddedMesh(embedded_mesh, intersection_neighbors, intersection_boundary_faces, intersection_cells)
+    return EmbeddedMesh(embedded_mesh, intersection_neighbors, intersection_faces, intersection_cells)
 end
 
 function Jutul.UnstructuredMesh(mesh::EmbeddedMesh)
@@ -91,7 +92,7 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
 
     # Handle intersection
     neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges,
-    face_edge_signs, face_edge_pos, intersection_neighbors, intersection_boundary_edges,
+    face_edge_signs, face_edge_pos, intersection_neighbors, intersection_edges,
     intersection_cells =
     split_intersections(
         neighbors,
@@ -108,29 +109,38 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
     # Fix orientation of edges
     N = fix_edge_orientation(neighbors, face_edges, face_edge_signs, face_edge_pos)
 
-    # Convert from mesh face ids to boundary-local face ids used by boundary arrays.
-    intersection_boundary_edges = remap_intersection_boundary_faces(intersection_boundary_edges, N)
+    # Remap raw edge indices to boundary-local or internal face indices
+    intersection_edges = remap_intersection_edges(intersection_edges, N, intersection_strategy)
     
     # Create unstructured mesh
     mesh_2d = UnstructuredMesh(face_edges, face_edge_pos, edge_nodes, edge_node_pos, node_points, N)
 
-    return mesh_2d, intersection_neighbors, intersection_boundary_edges, intersection_cells
+    return mesh_2d, intersection_neighbors, intersection_edges, intersection_cells
 
 end
 
-function remap_intersection_boundary_faces(intersection_boundary_edges, N)
+function remap_intersection_edges(intersection_edges, N, strategy)
     nfaces = size(N, 2)
-    boundary_mesh_faces = findall(i -> N[1, i] == 0 || N[2, i] == 0, 1:nfaces)
-    boundary_map = Dict{Int, Int}(f => i for (i, f) in enumerate(boundary_mesh_faces))
+    if strategy == :remove
+        # Boundary edges: remap to boundary-local face indices
+        boundary_mesh_faces = findall(i -> N[1, i] == 0 || N[2, i] == 0, 1:nfaces)
+        face_map = Dict{Int, Int}(f => i for (i, f) in enumerate(boundary_mesh_faces))
+        label = "boundary"
+    else
+        # Internal edges: remap to internal face indices
+        internal_mesh_faces = findall(i -> N[1, i] != 0 && N[2, i] != 0, 1:nfaces)
+        face_map = Dict{Int, Int}(f => i for (i, f) in enumerate(internal_mesh_faces))
+        label = "internal"
+    end
 
-    mapped = Vector{Vector{Int}}(undef, length(intersection_boundary_edges))
-    for i in eachindex(intersection_boundary_edges)
-        ix = intersection_boundary_edges[i]
+    mapped = Vector{Vector{Int}}(undef, length(intersection_edges))
+    for i in eachindex(intersection_edges)
+        ix = intersection_edges[i]
         mapped_ix = Int[]
         sizehint!(mapped_ix, length(ix))
         for f in ix
-            haskey(boundary_map, f) || error("Intersection face $f is not a boundary face in constructed mesh.")
-            push!(mapped_ix, boundary_map[f])
+            haskey(face_map, f) || error("Intersection edge $f is not a $label face in constructed mesh.")
+            push!(mapped_ix, face_map[f])
         end
         mapped[i] = mapped_ix
     end
@@ -209,7 +219,7 @@ function split_intersections(
     replacements = [Dict{Int, Vector{Int}}() for _ in 1:length(neighbors)]
 
     intersection_neighbors = Vector{Vector{Int}}()
-    intersection_boundary_edges = Vector{Vector{Int}}()
+    intersection_edges = Vector{Vector{Int}}()
     intersection_cells = Int[]
     intersection_cell_edges = Vector{Vector{Int}}()
     intersection_cell_edge_signs = Vector{Vector{Int}}()
@@ -231,6 +241,7 @@ function split_intersections(
         if length(faces) > 2
             if strategy == :star_delta
                 # Intersection: create pairwise internal connections.
+                ix_edges = Int[]
                 for i in 1:length(faces)
                     for j in (i+1):length(faces)
                         f1 = faces[i]
@@ -241,12 +252,12 @@ function split_intersections(
                         push!(new_num_nodes_per_edge, n_nodes)
 
                         new_edge_idx = length(new_neighbors)
-
+                        push!(ix_edges, new_edge_idx)
                         register_replacement!(old_edge_idx, f1, new_edge_idx)
                         register_replacement!(old_edge_idx, f2, new_edge_idx)
                     end
                 end
-                push!(intersection_boundary_edges, Int[])
+                push!(intersection_edges, ix_edges)
             elseif strategy == :remove
                 # Intersection: duplicate as boundary edge per face.
                 ix_boundary_edges = Int[]
@@ -259,7 +270,7 @@ function split_intersections(
                     push!(ix_boundary_edges, new_edge_idx)
                     register_replacement!(old_edge_idx, f, new_edge_idx)
                 end
-                push!(intersection_boundary_edges, ix_boundary_edges)
+                push!(intersection_edges, ix_boundary_edges)
             elseif strategy == :keep
                 ix_cell = num_faces + length(intersection_cells) + 1
                 ix_edges = Int[]
@@ -280,7 +291,7 @@ function split_intersections(
                     push!(ix_edge_signs, -face_edge_signs[face_positions[face_pos]])
                 end
 
-                push!(intersection_boundary_edges, Int[])
+                push!(intersection_edges, ix_edges)
                 push!(intersection_cells, ix_cell)
                 push!(intersection_cell_edges, ix_edges)
                 push!(intersection_cell_edge_signs, ix_edge_signs)
@@ -340,7 +351,7 @@ function split_intersections(
 
     num_ix_faces = length(intersection_cells)
 
-    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_neighbors, intersection_boundary_edges, intersection_cells
+    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_neighbors, intersection_edges, intersection_cells
 
 end
 

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -89,7 +89,7 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
 
     # Handle intersection
     neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges,
-    face_edge_signs, face_edge_pos, intersection_faces, intersection_boundary_edges =
+    face_edge_signs, face_edge_pos, intersection_neighbors, intersection_boundary_edges =
     split_intersections(
         neighbors,
         face_edges,
@@ -111,7 +111,7 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
     # Create unstructured mesh
     mesh_2d = UnstructuredMesh(face_edges, face_edge_pos, edge_nodes, edge_node_pos, node_points, N)
 
-    return mesh_2d, intersection_faces, intersection_boundary_edges
+    return mesh_2d, intersection_neighbors, intersection_boundary_edges
 
 end
 
@@ -205,7 +205,7 @@ function split_intersections(
     # We use a Vector of Dicts
     replacements = [Dict{Int, Vector{Int}}() for _ in 1:length(neighbors)]
 
-    intersection_faces = Vector{Vector{Int}}()
+    intersection_neighbors = Vector{Vector{Int}}()
     intersection_boundary_edges = Vector{Vector{Int}}()
 
     # Iterate over original edges
@@ -263,7 +263,7 @@ function split_intersections(
                 error("Unknown intersection strategy: $strategy")
             end
             # Store faces that are part of intersection
-            push!(intersection_faces, faces)
+            push!(intersection_neighbors, faces)
         else
             # Normal edge or boundary
             push!(new_neighbors, faces)
@@ -312,7 +312,7 @@ function split_intersections(
     
     num_ix_faces = 0
 
-    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_faces, intersection_boundary_edges
+    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_neighbors, intersection_boundary_edges
 
 end
 

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -7,14 +7,12 @@ interconnected faces.
 
 # Fields
 - `unstructured_mesh::UnstructuredMesh`: The underlying unstructured mesh representation
-- `intersections::Vector{Vector{Int}}`: Backward-compatible alias for `intersection_neighbors`
 - `intersection_neighbors::Vector{Vector{Int}}`: Embedded mesh cells grouped per intersection
 - `intersection_boundary_faces::Vector{Vector{Int}}`: Boundary-local face indices per intersection,
   aligned with `intersection_neighbors`
 """
 struct EmbeddedMesh <: Jutul.FiniteVolumeMesh
     unstructured_mesh::UnstructuredMesh
-    intersections::Vector{Vector{Int}}
     intersection_neighbors::Vector{Vector{Int}}
     intersection_boundary_faces::Vector{Vector{Int}}
 end
@@ -29,29 +27,23 @@ Construct an embedded mesh from selected faces of an unstructured mesh.
 - `faces`: Collection of face indices to include in the embedded mesh
 
 # Keyword arguments
-- `include_intersection_connections::Bool = false`: If `true`, intersections
-    with three or more faces are split into pairwise internal connections. If
-    `false` (default), intersection edges are kept disconnected in the
-    neighborship and stored in `intersections`.
+- `intersection_strategy::Symbol = :keep`: Strategy for handling intersections.
+    - `:keep` (default): Intersection edges are kept disconnected in the
+      neighborship and stored in `intersections`.
+    - `:star_delta`: Intersections with three or more faces are split into pairwise internal connections.
 
 # Returns
 - `EmbeddedMesh`: Embedded mesh made up of the specified faces.
 
 """
-function EmbeddedMesh(mesh::UnstructuredMesh, faces; include_intersection_connections = false)
-    embedded_mesh, intersections, intersection_boundary_faces = make_mesh_from_faces(
+function EmbeddedMesh(mesh::UnstructuredMesh, faces; intersection_strategy = :star_delta)
+    embedded_mesh, intersection_neighbors, intersection_boundary_faces = make_mesh_from_faces(
         mesh,
         faces;
-        include_intersection_connections = include_intersection_connections
+        intersection_strategy = intersection_strategy
     )
-    return EmbeddedMesh(embedded_mesh, intersections, intersections, intersection_boundary_faces)
+    return EmbeddedMesh(embedded_mesh, intersection_neighbors, intersection_boundary_faces)
 end
-
-EmbeddedMesh(mesh::UnstructuredMesh, intersections::Vector{Vector{Int}}) =
-    EmbeddedMesh(mesh, intersections, intersections, Vector{Vector{Int}}())
-
-EmbeddedMesh(mesh::UnstructuredMesh, intersections::Vector{Vector{Int}}, intersection_neighbors::Vector{Vector{Int}}) =
-    EmbeddedMesh(mesh, intersections, intersection_neighbors, Vector{Vector{Int}}())
 
 function Jutul.UnstructuredMesh(mesh::EmbeddedMesh)
     return mesh.unstructured_mesh
@@ -62,7 +54,7 @@ end
 
 Helper for EmbeddedMesh constructor.
 """
-function make_mesh_from_faces(mesh, faces; include_intersection_connections = false)
+function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
 
     # Make edges
     face_edges, num_edges_per_face, face_edge_signs, neighbors = get_face_edges(mesh, faces)
@@ -106,7 +98,7 @@ function make_mesh_from_faces(mesh, faces; include_intersection_connections = fa
         length(faces),
         edge_nodes,
         num_nodes_per_edge;
-        include_intersection_connections = include_intersection_connections
+        strategy = intersection_strategy
     )
     edge_node_pos = cumsum([1; num_nodes_per_edge])
 
@@ -200,7 +192,7 @@ function split_intersections(
     num_faces,
     edge_nodes,
     num_nodes_per_edge;
-    include_intersection_connections = false
+    strategy = :star_delta,
 )
 
     new_neighbors = Vector{Vector{Int}}()
@@ -224,7 +216,7 @@ function split_intersections(
         current_edge_node_idx += n_nodes
 
         if length(faces) > 2
-            if include_intersection_connections
+            if strategy == :star_delta
                 # Intersection: create pairwise internal connections.
                 for i in 1:length(faces)
                     for j in (i+1):length(faces)

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -9,11 +9,14 @@ interconnected faces.
 - `unstructured_mesh::UnstructuredMesh`: The underlying unstructured mesh representation
 - `intersections::Vector{Vector{Int}}`: Backward-compatible alias for `intersection_neighbors`
 - `intersection_neighbors::Vector{Vector{Int}}`: Embedded mesh cells grouped per intersection
+- `intersection_boundary_faces::Vector{Vector{Int}}`: Boundary-local face indices per intersection,
+  aligned with `intersection_neighbors`
 """
 struct EmbeddedMesh <: Jutul.FiniteVolumeMesh
     unstructured_mesh::UnstructuredMesh
     intersections::Vector{Vector{Int}}
     intersection_neighbors::Vector{Vector{Int}}
+    intersection_boundary_faces::Vector{Vector{Int}}
 end
 
 """
@@ -36,16 +39,19 @@ Construct an embedded mesh from selected faces of an unstructured mesh.
 
 """
 function EmbeddedMesh(mesh::UnstructuredMesh, faces; include_intersection_connections = false)
-    embedded_mesh, intersections = make_mesh_from_faces(
+    embedded_mesh, intersections, intersection_boundary_faces = make_mesh_from_faces(
         mesh,
         faces;
         include_intersection_connections = include_intersection_connections
     )
-    return EmbeddedMesh(embedded_mesh, intersections, intersections)
+    return EmbeddedMesh(embedded_mesh, intersections, intersections, intersection_boundary_faces)
 end
 
 EmbeddedMesh(mesh::UnstructuredMesh, intersections::Vector{Vector{Int}}) =
-    EmbeddedMesh(mesh, intersections, intersections)
+    EmbeddedMesh(mesh, intersections, intersections, Vector{Vector{Int}}())
+
+EmbeddedMesh(mesh::UnstructuredMesh, intersections::Vector{Vector{Int}}, intersection_neighbors::Vector{Vector{Int}}) =
+    EmbeddedMesh(mesh, intersections, intersection_neighbors, Vector{Vector{Int}}())
 
 function Jutul.UnstructuredMesh(mesh::EmbeddedMesh)
     return mesh.unstructured_mesh
@@ -90,8 +96,8 @@ function make_mesh_from_faces(mesh, faces; include_intersection_connections = fa
     # edge_node_pos = cumsum([1; num_nodes_per_edge])
 
     # Handle intersection
-    neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges, 
-    face_edge_signs, face_edge_pos, intersection_faces = 
+    neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges,
+    face_edge_signs, face_edge_pos, intersection_faces, intersection_boundary_faces =
     split_intersections(
         neighbors,
         face_edges,
@@ -106,12 +112,34 @@ function make_mesh_from_faces(mesh, faces; include_intersection_connections = fa
 
     # Fix orientation of edges
     N = fix_edge_orientation(neighbors, face_edges, face_edge_signs, face_edge_pos)
+
+    # Convert from mesh face ids to boundary-local face ids used by boundary arrays.
+    intersection_boundary_faces = remap_intersection_boundary_faces(intersection_boundary_faces, N)
     
     # Create unstructured mesh
     mesh_2d = UnstructuredMesh(face_edges, face_edge_pos, edge_nodes, edge_node_pos, node_points, N)
 
-    return mesh_2d, intersection_faces
+    return mesh_2d, intersection_faces, intersection_boundary_faces
 
+end
+
+function remap_intersection_boundary_faces(intersection_boundary_faces, N)
+    nfaces = size(N, 2)
+    boundary_mesh_faces = findall(i -> N[1, i] == 0 || N[2, i] == 0, 1:nfaces)
+    boundary_map = Dict{Int, Int}(f => i for (i, f) in enumerate(boundary_mesh_faces))
+
+    mapped = Vector{Vector{Int}}(undef, length(intersection_boundary_faces))
+    for i in eachindex(intersection_boundary_faces)
+        ix = intersection_boundary_faces[i]
+        mapped_ix = Int[]
+        sizehint!(mapped_ix, length(ix))
+        for f in ix
+            haskey(boundary_map, f) || error("Intersection face $f is not a boundary face in constructed mesh.")
+            push!(mapped_ix, boundary_map[f])
+        end
+        mapped[i] = mapped_ix
+    end
+    return mapped
 end
 
 function get_face_edges(mesh, faces)
@@ -186,6 +214,7 @@ function split_intersections(
     replacements = [Dict{Int, Vector{Int}}() for _ in 1:length(neighbors)]
 
     intersection_faces = Vector{Vector{Int}}()
+    intersection_boundary_faces = Vector{Vector{Int}}()
 
     # Iterate over original edges
     for (old_edge_idx, faces) in enumerate(neighbors)
@@ -219,19 +248,23 @@ function split_intersections(
                         push!(replacements[old_edge_idx][f2], new_edge_idx)
                     end
                 end
+                push!(intersection_boundary_faces, Int[])
             else
                 # Intersection: duplicate as boundary edge per face.
+                ix_boundary_faces = Int[]
                 for f in faces
                     push!(new_neighbors, [f])
                     append!(new_edge_nodes, nodes)
                     push!(new_num_nodes_per_edge, n_nodes)
 
                     new_edge_idx = length(new_neighbors)
+                    push!(ix_boundary_faces, new_edge_idx)
                     if !haskey(replacements[old_edge_idx], f)
                         replacements[old_edge_idx][f] = Int[]
                     end
                     push!(replacements[old_edge_idx][f], new_edge_idx)
                 end
+                push!(intersection_boundary_faces, ix_boundary_faces)
             end
             # Store faces that are part of intersection
             push!(intersection_faces, faces)
@@ -283,7 +316,7 @@ function split_intersections(
     
     num_ix_faces = 0
 
-    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_faces
+    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_faces, intersection_boundary_faces
 
 end
 

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -7,6 +7,7 @@ interconnected faces.
 
 # Fields
 - `unstructured_mesh::UnstructuredMesh`: The underlying unstructured mesh representation
+- `parent_faces::Vector{Int}`: Indices of the parent mesh faces that make up the embedded mesh
 - `intersection_neighbors::Vector{Vector{Int}}`: Embedded mesh cells grouped per intersection
 - `intersection_faces::Vector{Vector{Int}}`: Face indices per intersection, aligned with
   `intersection_neighbors`. For `:remove`, these are boundary face indices; for `:star_delta`
@@ -32,9 +33,12 @@ Construct an embedded mesh from selected faces of an unstructured mesh.
 
 # Keyword arguments
 - `intersection_strategy::Symbol = :keep`: Strategy for handling intersections.
-    - `:keep` (default): Intersection edges are kept disconnected in the
-      neighborship and stored in `intersections`.
-    - `:star_delta`: Intersections with three or more faces are split into pairwise internal connections.
+    - `:star_delta` (default): Intersections with three or more faces are split
+      into pairwise internal connections.
+    - `:remove`: Intersections are removed by duplicating the intersecting edge
+      as a boundary edge for each face.
+    - `:keep`: Intersections are kept as-is, with an additional cell created for
+      each intersection and connected to all intersecting faces.
 
 # Returns
 - `EmbeddedMesh`: Embedded mesh made up of the specified faces.

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -10,11 +10,13 @@ interconnected faces.
 - `intersection_neighbors::Vector{Vector{Int}}`: Embedded mesh cells grouped per intersection
 - `intersection_boundary_faces::Vector{Vector{Int}}`: Boundary-local face indices per intersection,
   aligned with `intersection_neighbors`
+- `intersection_cells::Vector{Int}`: Embedded mesh cell indices created for kept intersections
 """
 struct EmbeddedMesh <: Jutul.FiniteVolumeMesh
     unstructured_mesh::UnstructuredMesh
     intersection_neighbors::Vector{Vector{Int}}
     intersection_boundary_faces::Vector{Vector{Int}}
+    intersection_cells::Vector{Int}
 end
 
 """
@@ -37,12 +39,12 @@ Construct an embedded mesh from selected faces of an unstructured mesh.
 
 """
 function EmbeddedMesh(mesh::UnstructuredMesh, faces; intersection_strategy = :star_delta)
-    embedded_mesh, intersection_neighbors, intersection_boundary_faces = make_mesh_from_faces(
+    embedded_mesh, intersection_neighbors, intersection_boundary_faces, intersection_cells = make_mesh_from_faces(
         mesh,
         faces;
         intersection_strategy = intersection_strategy
     )
-    return EmbeddedMesh(embedded_mesh, intersection_neighbors, intersection_boundary_faces)
+    return EmbeddedMesh(embedded_mesh, intersection_neighbors, intersection_boundary_faces, intersection_cells)
 end
 
 function Jutul.UnstructuredMesh(mesh::EmbeddedMesh)
@@ -89,7 +91,8 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
 
     # Handle intersection
     neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges,
-    face_edge_signs, face_edge_pos, intersection_neighbors, intersection_boundary_edges =
+    face_edge_signs, face_edge_pos, intersection_neighbors, intersection_boundary_edges,
+    intersection_cells =
     split_intersections(
         neighbors,
         face_edges,
@@ -111,7 +114,7 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
     # Create unstructured mesh
     mesh_2d = UnstructuredMesh(face_edges, face_edge_pos, edge_nodes, edge_node_pos, node_points, N)
 
-    return mesh_2d, intersection_neighbors, intersection_boundary_edges
+    return mesh_2d, intersection_neighbors, intersection_boundary_edges, intersection_cells
 
 end
 
@@ -207,6 +210,16 @@ function split_intersections(
 
     intersection_neighbors = Vector{Vector{Int}}()
     intersection_boundary_edges = Vector{Vector{Int}}()
+    intersection_cells = Int[]
+    intersection_cell_edges = Vector{Vector{Int}}()
+    intersection_cell_edge_signs = Vector{Vector{Int}}()
+
+    function register_replacement!(old_edge_idx, face_idx, new_edge_idx)
+        if !haskey(replacements[old_edge_idx], face_idx)
+            replacements[old_edge_idx][face_idx] = Int[]
+        end
+        push!(replacements[old_edge_idx][face_idx], new_edge_idx)
+    end
 
     # Iterate over original edges
     for (old_edge_idx, faces) in enumerate(neighbors)
@@ -229,15 +242,8 @@ function split_intersections(
 
                         new_edge_idx = length(new_neighbors)
 
-                        if !haskey(replacements[old_edge_idx], f1)
-                            replacements[old_edge_idx][f1] = Int[]
-                        end
-                        push!(replacements[old_edge_idx][f1], new_edge_idx)
-
-                        if !haskey(replacements[old_edge_idx], f2)
-                            replacements[old_edge_idx][f2] = Int[]
-                        end
-                        push!(replacements[old_edge_idx][f2], new_edge_idx)
+                        register_replacement!(old_edge_idx, f1, new_edge_idx)
+                        register_replacement!(old_edge_idx, f2, new_edge_idx)
                     end
                 end
                 push!(intersection_boundary_edges, Int[])
@@ -251,14 +257,33 @@ function split_intersections(
 
                     new_edge_idx = length(new_neighbors)
                     push!(ix_boundary_edges, new_edge_idx)
-                    if !haskey(replacements[old_edge_idx], f)
-                        replacements[old_edge_idx][f] = Int[]
-                    end
-                    push!(replacements[old_edge_idx][f], new_edge_idx)
+                    register_replacement!(old_edge_idx, f, new_edge_idx)
                 end
                 push!(intersection_boundary_edges, ix_boundary_edges)
             elseif strategy == :keep
-                 error("Not implemented yet")
+                ix_cell = num_faces + length(intersection_cells) + 1
+                ix_edges = Int[]
+                ix_edge_signs = Int[]
+
+                for f in faces
+                    push!(new_neighbors, [f, ix_cell])
+                    append!(new_edge_nodes, nodes)
+                    push!(new_num_nodes_per_edge, n_nodes)
+
+                    new_edge_idx = length(new_neighbors)
+                    push!(ix_edges, new_edge_idx)
+                    register_replacement!(old_edge_idx, f, new_edge_idx)
+
+                    face_positions = face_edge_pos[f]:(face_edge_pos[f + 1] - 1)
+                    face_pos = findfirst(face_edges[face_positions] .== old_edge_idx)
+                    isnothing(face_pos) && error("Edge $old_edge_idx not found in face $f")
+                    push!(ix_edge_signs, -face_edge_signs[face_positions[face_pos]])
+                end
+
+                push!(intersection_boundary_edges, Int[])
+                push!(intersection_cells, ix_cell)
+                push!(intersection_cell_edges, ix_edges)
+                push!(intersection_cell_edge_signs, ix_edge_signs)
             else
                 error("Unknown intersection strategy: $strategy")
             end
@@ -273,10 +298,7 @@ function split_intersections(
             new_edge_idx = length(new_neighbors)
             
             for f in faces
-                if !haskey(replacements[old_edge_idx], f)
-                    replacements[old_edge_idx][f] = Int[]
-                end
-                push!(replacements[old_edge_idx][f], new_edge_idx)
+                register_replacement!(old_edge_idx, f, new_edge_idx)
             end
         end
     end
@@ -309,10 +331,16 @@ function split_intersections(
         end
         push!(new_face_edge_pos, length(new_face_edges) + 1)
     end
-    
-    num_ix_faces = 0
 
-    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_neighbors, intersection_boundary_edges
+    for (ix_edges, ix_signs) in zip(intersection_cell_edges, intersection_cell_edge_signs)
+        append!(new_face_edges, ix_edges)
+        append!(new_face_edge_signs, ix_signs)
+        push!(new_face_edge_pos, length(new_face_edges) + 1)
+    end
+
+    num_ix_faces = length(intersection_cells)
+
+    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_neighbors, intersection_boundary_edges, intersection_cells
 
 end
 

--- a/src/meshes/EmbeddedMeshes/types.jl
+++ b/src/meshes/EmbeddedMeshes/types.jl
@@ -89,7 +89,7 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
 
     # Handle intersection
     neighbors, num_ix_faces, edge_nodes, num_nodes_per_edge, face_edges,
-    face_edge_signs, face_edge_pos, intersection_faces, intersection_boundary_faces =
+    face_edge_signs, face_edge_pos, intersection_faces, intersection_boundary_edges =
     split_intersections(
         neighbors,
         face_edges,
@@ -106,23 +106,23 @@ function make_mesh_from_faces(mesh, faces; intersection_strategy = :star_delta)
     N = fix_edge_orientation(neighbors, face_edges, face_edge_signs, face_edge_pos)
 
     # Convert from mesh face ids to boundary-local face ids used by boundary arrays.
-    intersection_boundary_faces = remap_intersection_boundary_faces(intersection_boundary_faces, N)
+    intersection_boundary_edges = remap_intersection_boundary_faces(intersection_boundary_edges, N)
     
     # Create unstructured mesh
     mesh_2d = UnstructuredMesh(face_edges, face_edge_pos, edge_nodes, edge_node_pos, node_points, N)
 
-    return mesh_2d, intersection_faces, intersection_boundary_faces
+    return mesh_2d, intersection_faces, intersection_boundary_edges
 
 end
 
-function remap_intersection_boundary_faces(intersection_boundary_faces, N)
+function remap_intersection_boundary_faces(intersection_boundary_edges, N)
     nfaces = size(N, 2)
     boundary_mesh_faces = findall(i -> N[1, i] == 0 || N[2, i] == 0, 1:nfaces)
     boundary_map = Dict{Int, Int}(f => i for (i, f) in enumerate(boundary_mesh_faces))
 
-    mapped = Vector{Vector{Int}}(undef, length(intersection_boundary_faces))
-    for i in eachindex(intersection_boundary_faces)
-        ix = intersection_boundary_faces[i]
+    mapped = Vector{Vector{Int}}(undef, length(intersection_boundary_edges))
+    for i in eachindex(intersection_boundary_edges)
+        ix = intersection_boundary_edges[i]
         mapped_ix = Int[]
         sizehint!(mapped_ix, length(ix))
         for f in ix
@@ -206,7 +206,7 @@ function split_intersections(
     replacements = [Dict{Int, Vector{Int}}() for _ in 1:length(neighbors)]
 
     intersection_faces = Vector{Vector{Int}}()
-    intersection_boundary_faces = Vector{Vector{Int}}()
+    intersection_boundary_edges = Vector{Vector{Int}}()
 
     # Iterate over original edges
     for (old_edge_idx, faces) in enumerate(neighbors)
@@ -240,23 +240,27 @@ function split_intersections(
                         push!(replacements[old_edge_idx][f2], new_edge_idx)
                     end
                 end
-                push!(intersection_boundary_faces, Int[])
-            else
+                push!(intersection_boundary_edges, Int[])
+            elseif strategy == :remove
                 # Intersection: duplicate as boundary edge per face.
-                ix_boundary_faces = Int[]
+                ix_boundary_edges = Int[]
                 for f in faces
                     push!(new_neighbors, [f])
                     append!(new_edge_nodes, nodes)
                     push!(new_num_nodes_per_edge, n_nodes)
 
                     new_edge_idx = length(new_neighbors)
-                    push!(ix_boundary_faces, new_edge_idx)
+                    push!(ix_boundary_edges, new_edge_idx)
                     if !haskey(replacements[old_edge_idx], f)
                         replacements[old_edge_idx][f] = Int[]
                     end
                     push!(replacements[old_edge_idx][f], new_edge_idx)
                 end
-                push!(intersection_boundary_faces, ix_boundary_faces)
+                push!(intersection_boundary_edges, ix_boundary_edges)
+            elseif strategy == :keep
+                 error("Not implemented yet")
+            else
+                error("Unknown intersection strategy: $strategy")
             end
             # Store faces that are part of intersection
             push!(intersection_faces, faces)
@@ -308,7 +312,7 @@ function split_intersections(
     
     num_ix_faces = 0
 
-    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_faces, intersection_boundary_faces
+    return new_neighbors, num_ix_faces, new_edge_nodes, new_num_nodes_per_edge, new_face_edges, new_face_edge_signs, new_face_edge_pos, intersection_faces, intersection_boundary_edges
 
 end
 

--- a/test/embedded_meshes.jl
+++ b/test/embedded_meshes.jl
@@ -32,6 +32,11 @@ using Jutul.EmbeddedMeshes
         
         fracture_faces = findall(face_mask)
         embedded_mesh = Jutul.EmbeddedMeshes.EmbeddedMesh(parent_mesh, fracture_faces)
+        embedded_mesh_with_connections = Jutul.EmbeddedMeshes.EmbeddedMesh(
+            parent_mesh,
+            fracture_faces;
+            include_intersection_connections = true
+        )
         
         @testset "EmbeddedMesh Construction" begin
             # Create embedded mesh
@@ -39,12 +44,19 @@ using Jutul.EmbeddedMeshes
             @test embedded_mesh isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh.unstructured_mesh isa Jutul.UnstructuredMesh
             @test embedded_mesh.intersections isa Vector{Vector{Int}}
+            @test embedded_mesh.intersection_neighbors isa Vector{Vector{Int}}
+            @test embedded_mesh_with_connections isa Jutul.EmbeddedMeshes.EmbeddedMesh
+            @test embedded_mesh_with_connections.intersections == embedded_mesh.intersections
+            @test embedded_mesh.intersection_neighbors == embedded_mesh.intersections
+            @test embedded_mesh_with_connections.intersection_neighbors == embedded_mesh_with_connections.intersections
             
             # Test basic interface functions
             @test dim(embedded_mesh) == 3  # Embedded features are 2D, but have 3D coordinates
             @test number_of_cells(embedded_mesh) == length(fracture_faces)  # Each face should become a cell in the embedded mesh
-            @test number_of_faces(embedded_mesh) == 18 + 3*6
-            @test number_of_boundary_faces(embedded_mesh) == 24
+            @test number_of_faces(embedded_mesh_with_connections) == 18 + 3*6
+            @test number_of_boundary_faces(embedded_mesh_with_connections) == 24
+            @test number_of_faces(embedded_mesh) < number_of_faces(embedded_mesh_with_connections)
+            @test number_of_boundary_faces(embedded_mesh) > number_of_boundary_faces(embedded_mesh_with_connections)
         end
         
         @testset "Connectivity Verification" begin
@@ -60,6 +72,10 @@ using Jutul.EmbeddedMeshes
             @test length(umesh.faces.neighbors) == nf
             @test length(umesh.boundary_faces.neighbors) == nbf
             @test all(length.(embedded_mesh.intersections) .== 4)
+
+            umesh_connected = embedded_mesh_with_connections.unstructured_mesh
+            @test all(length.(embedded_mesh_with_connections.intersections) .== 4)
+            @test length(umesh_connected.faces.neighbors) > length(umesh.faces.neighbors)
             
             # Check neighbor consistency
             neighbors = get_neighborship(embedded_mesh)
@@ -71,6 +87,26 @@ using Jutul.EmbeddedMeshes
             for i in 1:nf
                 @test neighbors[1, i] != neighbors[2, i]
             end
+
+            # Default behavior should not create internal intersection links.
+            for ix in embedded_mesh.intersections
+                ix_set = Set(ix)
+                has_internal_ix_link = any(eachcol(neighbors)) do n
+                    (n[1] in ix_set) && (n[2] in ix_set)
+                end
+                @test !has_internal_ix_link
+            end
+
+            # Opt-in behavior should include internal links at intersections.
+            neighbors_connected = get_neighborship(embedded_mesh_with_connections)
+            total_ix_links = 0
+            for ix in embedded_mesh_with_connections.intersections
+                ix_set = Set(ix)
+                total_ix_links += count(eachcol(neighbors_connected)) do n
+                    (n[1] in ix_set) && (n[2] in ix_set)
+                end
+            end
+            @test total_ix_links > 0
         end
         
         @testset "Geometric Consistency" begin

--- a/test/embedded_meshes.jl
+++ b/test/embedded_meshes.jl
@@ -53,15 +53,15 @@ using Jutul.EmbeddedMeshes
             @test embedded_mesh_remove isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh_remove.unstructured_mesh isa Jutul.UnstructuredMesh
             @test embedded_mesh_remove.intersection_neighbors isa Vector{Vector{Int}}
-            @test embedded_mesh_remove.intersection_edges isa Vector{Vector{Int}}
+            @test embedded_mesh_remove.intersection_faces isa Vector{Vector{Int}}
             @test embedded_mesh_remove.intersection_cells == Int[]
             @test embedded_mesh_star isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh_star.intersection_neighbors == embedded_mesh_remove.intersection_neighbors
-            @test all(!isempty, embedded_mesh_star.intersection_edges)
+            @test all(!isempty, embedded_mesh_star.intersection_faces)
             @test embedded_mesh_star.intersection_cells == Int[]
             @test embedded_mesh_keep isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh_keep.intersection_neighbors == embedded_mesh_remove.intersection_neighbors
-            @test all(!isempty, embedded_mesh_keep.intersection_edges)
+            @test all(!isempty, embedded_mesh_keep.intersection_faces)
             @test length(embedded_mesh_keep.intersection_cells) == length(embedded_mesh_keep.intersection_neighbors)
             
             # Test basic interface functions
@@ -87,7 +87,7 @@ using Jutul.EmbeddedMeshes
             @test length(umesh.faces.neighbors) == nf
             @test length(umesh.boundary_faces.neighbors) == nbf
             @test all(length.(embedded_mesh_remove.intersection_neighbors) .== 4)
-            @test all(length.(embedded_mesh_remove.intersection_edges) .== 4)
+            @test all(length.(embedded_mesh_remove.intersection_faces) .== 4)
 
             umesh_connected = embedded_mesh_star.unstructured_mesh
             @test all(length.(embedded_mesh_star.intersection_neighbors) .== 4)
@@ -105,7 +105,7 @@ using Jutul.EmbeddedMeshes
             end
 
             # Remove strategy should disconnect the intersection into boundary faces.
-            for (ix, ix_boundary_faces) in zip(embedded_mesh_remove.intersection_neighbors, embedded_mesh_remove.intersection_edges)
+            for (ix, ix_boundary_faces) in zip(embedded_mesh_remove.intersection_neighbors, embedded_mesh_remove.intersection_faces)
                 ix_set = Set(ix)
                 has_internal_ix_link = any(eachcol(neighbors)) do n
                     (n[1] in ix_set) && (n[2] in ix_set)
@@ -208,7 +208,47 @@ using Jutul.EmbeddedMeshes
         @test dim(umesh) == dim(embedded_mesh)
         @test number_of_cells(umesh) == number_of_cells(embedded_mesh)
     end
-    
+
+    @testset "Face and BoundaryFace Centroid/Measure" begin
+        parent_mesh = UnstructuredMesh(CartesianMesh((3, 3, 3), (3.0, 3.0, 3.0)))
+        test_faces = [1, 3, 5]
+        embedded_mesh = Jutul.EmbeddedMeshes.EmbeddedMesh(parent_mesh, test_faces)
+
+        nf = number_of_faces(embedded_mesh)
+        nbf = number_of_boundary_faces(embedded_mesh)
+
+        for f in 1:nf
+            centroid, measure = Jutul.compute_centroid_and_measure(embedded_mesh, Faces(), f)
+            @test length(centroid) == 3
+            @test measure > 0
+        end
+        for f in 1:nbf
+            centroid, measure = Jutul.compute_centroid_and_measure(embedded_mesh, BoundaryFaces(), f)
+            @test length(centroid) == 3
+            @test measure > 0
+        end
+    end
+
+    @testset "half_face_normal" begin
+        parent_mesh = UnstructuredMesh(CartesianMesh((2, 2, 2), (2.0, 2.0, 2.0)))
+        test_faces = [1, 2]
+        embedded_mesh = Jutul.EmbeddedMeshes.EmbeddedMesh(parent_mesh, test_faces)
+
+        N = get_neighborship(embedded_mesh)
+        nc = number_of_cells(embedded_mesh)
+        for cell in 1:nc
+            cn = Jutul.EmbeddedMeshes.cell_normal(embedded_mesh, cell)
+            umesh = embedded_mesh.unstructured_mesh
+            for face in umesh.faces.cells_to_faces[cell]
+                hfn = Jutul.EmbeddedMeshes.half_face_normal(embedded_mesh, face, cell, cn)
+                # Should be a unit vector
+                @test norm(hfn) ≈ 1.0
+                # Should be perpendicular to the cell normal
+                @test abs(dot(hfn, cn)) < 1e-12
+            end
+        end
+    end
+
     @testset "Transmissibility Computation" begin
         # Test specialized transmissibility calculations for embedded features
         parent_mesh = UnstructuredMesh(CartesianMesh((2, 2, 2), (2.0, 2.0, 2.0)))
@@ -218,12 +258,11 @@ using Jutul.EmbeddedMeshes
         # Set up basic finite volume geometry
         tpfv_geo = tpfv_geometry(embedded_mesh)
         nc = number_of_cells(embedded_mesh)
-        nf = number_of_faces(embedded_mesh)
         
         # Test transmissibility computation
         perm_scalar = 1e-12  # 1 mD
+        aperture = 1.0       # unit aperture
         N = get_neighborship(embedded_mesh)
-        nc = number_of_cells(embedded_mesh)
         faces, facepos = get_facepos(N, nc)
         T_hf = compute_half_face_trans(
             embedded_mesh,
@@ -231,11 +270,129 @@ using Jutul.EmbeddedMeshes
             tpfv_geo.face_centroids,
             tpfv_geo.areas,
             perm_scalar,
+            aperture,
             faces,
             facepos
         )
         
         @test length(T_hf) == length(faces)
-        @test all(T_hf .== 2.0e-12)  # Transmissibilities should be non-negative
+        @test all(T_hf .== 2.0e-12)
+        @test all(isfinite, T_hf)
+    end
+
+    @testset "compute_face_trans_dfm" begin
+        # Use the cross-shaped fracture network with star-delta strategy
+        parent_dims = (3, 3, 3)
+        parent_mesh = UnstructuredMesh(CartesianMesh(parent_dims, (4.0, 4.0, 4.0)))
+        neighbors = get_neighborship(parent_mesh)
+        ijk = reinterpret(reshape, Int, map(c -> cell_ijk(parent_mesh, c), 1:number_of_cells(parent_mesh)))
+
+        face_mask = falses(size(neighbors, 2))
+        for k = 1:parent_dims[3], j = 1:parent_dims[2]
+            cell_mask_l = (ijk[1,:] .== 1) .& (ijk[2,:] .== j) .& (ijk[3,:] .== k)
+            cell_mask_r = (ijk[1,:] .== 2) .& (ijk[2,:] .== j) .& (ijk[3,:] .== k)
+            face_mask = face_mask .| vec(any(cell_mask_l[neighbors], dims = 1) .& any(cell_mask_r[neighbors], dims = 1))
+        end
+        for k = 1:parent_dims[3], i = 1:parent_dims[1]
+            cell_mask_l = (ijk[1,:] .== i) .& (ijk[2,:] .== 1) .& (ijk[3,:] .== k)
+            cell_mask_r = (ijk[1,:] .== i) .& (ijk[2,:] .== 2) .& (ijk[3,:] .== k)
+            face_mask = face_mask .| vec(any(cell_mask_l[neighbors], dims = 1) .& any(cell_mask_r[neighbors], dims = 1))
+        end
+        fracture_faces = findall(face_mask)
+
+        # Test with star_delta strategy (has intersection connections)
+        mesh_star = Jutul.EmbeddedMeshes.EmbeddedMesh(parent_mesh, fracture_faces; intersection_strategy = :star_delta)
+        geo_star = tpfv_geometry(mesh_star)
+        N_star = get_neighborship(mesh_star)
+        nc_star = number_of_cells(mesh_star)
+        nf_star = number_of_faces(mesh_star)
+        faces_star, facepos_star = get_facepos(N_star, nc_star)
+        perm = 1e-12
+        aperture = 1e-3
+
+        T_hf_star = compute_half_face_trans(
+            mesh_star,
+            geo_star.cell_centroids,
+            geo_star.face_centroids,
+            geo_star.areas,
+            perm,
+            aperture,
+            faces_star,
+            facepos_star
+        )
+
+        intersections = mesh_star.intersection_neighbors
+        T_star = Jutul.EmbeddedMeshes.compute_face_trans_dfm(T_hf_star, N_star, intersections, true)
+        @test length(T_star) == nf_star
+        @test all(T_star .>= 0.0)
+        @test all(isfinite, T_star)
+
+        # Without star-delta correction (should still return valid transmissibilities)
+        T_no_sd = Jutul.EmbeddedMeshes.compute_face_trans_dfm(T_hf_star, N_star, intersections, false)
+        @test length(T_no_sd) == nf_star
+        @test all(T_no_sd .>= 0.0)
+        @test all(isfinite, T_no_sd)
+    end
+
+    @testset "compute_intersection_trans_dfm" begin
+        # Use the same cross-shaped fracture network
+        parent_dims = (3, 3, 3)
+        parent_mesh = UnstructuredMesh(CartesianMesh(parent_dims, (4.0, 4.0, 4.0)))
+        neighbors = get_neighborship(parent_mesh)
+        ijk = reinterpret(reshape, Int, map(c -> cell_ijk(parent_mesh, c), 1:number_of_cells(parent_mesh)))
+
+        face_mask = falses(size(neighbors, 2))
+        for k = 1:parent_dims[3], j = 1:parent_dims[2]
+            cell_mask_l = (ijk[1,:] .== 1) .& (ijk[2,:] .== j) .& (ijk[3,:] .== k)
+            cell_mask_r = (ijk[1,:] .== 2) .& (ijk[2,:] .== j) .& (ijk[3,:] .== k)
+            face_mask = face_mask .| vec(any(cell_mask_l[neighbors], dims = 1) .& any(cell_mask_r[neighbors], dims = 1))
+        end
+        for k = 1:parent_dims[3], i = 1:parent_dims[1]
+            cell_mask_l = (ijk[1,:] .== i) .& (ijk[2,:] .== 1) .& (ijk[3,:] .== k)
+            cell_mask_r = (ijk[1,:] .== i) .& (ijk[2,:] .== 2) .& (ijk[3,:] .== k)
+            face_mask = face_mask .| vec(any(cell_mask_l[neighbors], dims = 1) .& any(cell_mask_r[neighbors], dims = 1))
+        end
+        fracture_faces = findall(face_mask)
+
+        mesh_star = Jutul.EmbeddedMeshes.EmbeddedMesh(parent_mesh, fracture_faces; intersection_strategy = :star_delta)
+        geo_star = tpfv_geometry(mesh_star)
+        N_star = get_neighborship(mesh_star)
+        nc_star = number_of_cells(mesh_star)
+        faces_star, facepos_star = get_facepos(N_star, nc_star)
+        perm = 1e-12
+        aperture = 1e-3
+
+        T_hf = compute_half_face_trans(
+            mesh_star,
+            geo_star.cell_centroids,
+            geo_star.face_centroids,
+            geo_star.areas,
+            perm,
+            aperture,
+            faces_star,
+            facepos_star
+        )
+
+        intersections = mesh_star.intersection_neighbors
+        @test !isempty(intersections)
+
+        T_ix, ix_faces = Jutul.EmbeddedMeshes.compute_intersection_trans_dfm(T_hf, N_star, intersections)
+
+        # Each intersection with 4 neighbors produces 4*(4-1)/2 = 6 star-delta faces
+        @test length(T_ix) == length(ix_faces)
+        @test !isempty(T_ix)
+        @test all(T_ix .> 0.0)
+        @test all(isfinite, T_ix)
+
+        # All returned faces should be valid face indices
+        nf = size(N_star, 2)
+        @test all(1 .<= ix_faces .<= nf)
+
+        # Intersection faces should connect cells within the same intersection group
+        for f in ix_faces
+            ci, cj = N_star[:, f]
+            found = any(ix -> (ci in ix && cj in ix), intersections)
+            @test found
+        end
     end
 end

--- a/test/embedded_meshes.jl
+++ b/test/embedded_meshes.jl
@@ -31,54 +31,70 @@ using Jutul.EmbeddedMeshes
         end
         
         fracture_faces = findall(face_mask)
-        embedded_mesh = Jutul.EmbeddedMeshes.EmbeddedMesh(parent_mesh, fracture_faces)
-        embedded_mesh_with_connections = Jutul.EmbeddedMeshes.EmbeddedMesh(
+        embedded_mesh_remove = Jutul.EmbeddedMeshes.EmbeddedMesh(
             parent_mesh,
             fracture_faces;
-            include_intersection_connections = true
+            intersection_strategy = :remove
+        )
+        embedded_mesh_star = Jutul.EmbeddedMeshes.EmbeddedMesh(
+            parent_mesh,
+            fracture_faces;
+            intersection_strategy = :star_delta
+        )
+        embedded_mesh_keep = Jutul.EmbeddedMeshes.EmbeddedMesh(
+            parent_mesh,
+            fracture_faces;
+            intersection_strategy = :keep
         )
         
         @testset "EmbeddedMesh Construction" begin
             # Create embedded mesh
             
-            @test embedded_mesh isa Jutul.EmbeddedMeshes.EmbeddedMesh
-            @test embedded_mesh.unstructured_mesh isa Jutul.UnstructuredMesh
-            @test embedded_mesh.intersections isa Vector{Vector{Int}}
-            @test embedded_mesh.intersection_neighbors isa Vector{Vector{Int}}
-            @test embedded_mesh_with_connections isa Jutul.EmbeddedMeshes.EmbeddedMesh
-            @test embedded_mesh_with_connections.intersections == embedded_mesh.intersections
-            @test embedded_mesh.intersection_neighbors == embedded_mesh.intersections
-            @test embedded_mesh_with_connections.intersection_neighbors == embedded_mesh_with_connections.intersections
+            @test embedded_mesh_remove isa Jutul.EmbeddedMeshes.EmbeddedMesh
+            @test embedded_mesh_remove.unstructured_mesh isa Jutul.UnstructuredMesh
+            @test embedded_mesh_remove.intersection_neighbors isa Vector{Vector{Int}}
+            @test embedded_mesh_remove.intersection_boundary_faces isa Vector{Vector{Int}}
+            @test embedded_mesh_remove.intersection_cells == Int[]
+            @test embedded_mesh_star isa Jutul.EmbeddedMeshes.EmbeddedMesh
+            @test embedded_mesh_star.intersection_neighbors == embedded_mesh_remove.intersection_neighbors
+            @test embedded_mesh_star.intersection_boundary_faces == [Int[] for _ in embedded_mesh_star.intersection_neighbors]
+            @test embedded_mesh_star.intersection_cells == Int[]
+            @test embedded_mesh_keep isa Jutul.EmbeddedMeshes.EmbeddedMesh
+            @test embedded_mesh_keep.intersection_neighbors == embedded_mesh_remove.intersection_neighbors
+            @test embedded_mesh_keep.intersection_boundary_faces == [Int[] for _ in embedded_mesh_keep.intersection_neighbors]
+            @test length(embedded_mesh_keep.intersection_cells) == length(embedded_mesh_keep.intersection_neighbors)
             
             # Test basic interface functions
-            @test dim(embedded_mesh) == 3  # Embedded features are 2D, but have 3D coordinates
-            @test number_of_cells(embedded_mesh) == length(fracture_faces)  # Each face should become a cell in the embedded mesh
-            @test number_of_faces(embedded_mesh_with_connections) == 18 + 3*6
-            @test number_of_boundary_faces(embedded_mesh_with_connections) == 24
-            @test number_of_faces(embedded_mesh) < number_of_faces(embedded_mesh_with_connections)
-            @test number_of_boundary_faces(embedded_mesh) > number_of_boundary_faces(embedded_mesh_with_connections)
+            @test dim(embedded_mesh_remove) == 3
+            @test number_of_cells(embedded_mesh_remove) == length(fracture_faces)
+            @test number_of_cells(embedded_mesh_star) == length(fracture_faces)
+            @test number_of_cells(embedded_mesh_keep) == length(fracture_faces) + length(embedded_mesh_keep.intersection_cells)
+            @test number_of_faces(embedded_mesh_remove) < number_of_faces(embedded_mesh_star)
+            @test number_of_faces(embedded_mesh_keep) == number_of_faces(embedded_mesh_remove) + sum(length, embedded_mesh_keep.intersection_neighbors)
+            @test number_of_boundary_faces(embedded_mesh_remove) > number_of_boundary_faces(embedded_mesh_keep)
         end
         
         @testset "Connectivity Verification" begin
-            umesh = embedded_mesh.unstructured_mesh
+            umesh = embedded_mesh_remove.unstructured_mesh
                 
-            nc = number_of_cells(embedded_mesh)
-            nf = number_of_faces(embedded_mesh)
-            nbf = number_of_boundary_faces(embedded_mesh)
+            nc = number_of_cells(embedded_mesh_remove)
+            nf = number_of_faces(embedded_mesh_remove)
+            nbf = number_of_boundary_faces(embedded_mesh_remove)
             
             # Basic connectivity checks
             @test length(umesh.faces.cells_to_faces) == nc
             @test length(umesh.boundary_faces.cells_to_faces) == nc
             @test length(umesh.faces.neighbors) == nf
             @test length(umesh.boundary_faces.neighbors) == nbf
-            @test all(length.(embedded_mesh.intersections) .== 4)
+            @test all(length.(embedded_mesh_remove.intersection_neighbors) .== 4)
+            @test all(length.(embedded_mesh_remove.intersection_boundary_faces) .== 4)
 
-            umesh_connected = embedded_mesh_with_connections.unstructured_mesh
-            @test all(length.(embedded_mesh_with_connections.intersections) .== 4)
+            umesh_connected = embedded_mesh_star.unstructured_mesh
+            @test all(length.(embedded_mesh_star.intersection_neighbors) .== 4)
             @test length(umesh_connected.faces.neighbors) > length(umesh.faces.neighbors)
             
             # Check neighbor consistency
-            neighbors = get_neighborship(embedded_mesh)
+            neighbors = get_neighborship(embedded_mesh_remove)
             @test size(neighbors) == (2, nf)
             @test all(1 .<= neighbors[1, :] .<= nc)
             @test all(1 .<= neighbors[2, :] .<= nc)
@@ -88,34 +104,50 @@ using Jutul.EmbeddedMeshes
                 @test neighbors[1, i] != neighbors[2, i]
             end
 
-            # Default behavior should not create internal intersection links.
-            for ix in embedded_mesh.intersections
+            # Remove strategy should disconnect the intersection into boundary faces.
+            for (ix, ix_boundary_faces) in zip(embedded_mesh_remove.intersection_neighbors, embedded_mesh_remove.intersection_boundary_faces)
                 ix_set = Set(ix)
                 has_internal_ix_link = any(eachcol(neighbors)) do n
                     (n[1] in ix_set) && (n[2] in ix_set)
                 end
                 @test !has_internal_ix_link
+                @test length(ix_boundary_faces) == length(ix)
             end
 
-            # Opt-in behavior should include internal links at intersections.
-            neighbors_connected = get_neighborship(embedded_mesh_with_connections)
+            # Star-delta strategy should include internal links at intersections.
+            neighbors_connected = get_neighborship(embedded_mesh_star)
             total_ix_links = 0
-            for ix in embedded_mesh_with_connections.intersections
+            for ix in embedded_mesh_star.intersection_neighbors
                 ix_set = Set(ix)
                 total_ix_links += count(eachcol(neighbors_connected)) do n
                     (n[1] in ix_set) && (n[2] in ix_set)
                 end
             end
             @test total_ix_links > 0
+
+            # Keep strategy should attach duplicated edges to new intersection cells.
+            neighbors_keep = get_neighborship(embedded_mesh_keep)
+            for (ix_cells, ix_cell) in zip(embedded_mesh_keep.intersection_neighbors, embedded_mesh_keep.intersection_cells)
+                connected_faces = findall(f -> ix_cell in neighbors_keep[:, f], 1:size(neighbors_keep, 2))
+                connected_cells = Int[]
+                for f in connected_faces
+                    n = neighbors_keep[:, f]
+                    other = n[1] == ix_cell ? n[2] : n[1]
+                    push!(connected_cells, other)
+                end
+                sort!(connected_cells)
+                @test connected_cells == sort(ix_cells)
+                @test all(count(==(ix_cell), neighbors_keep[:, f]) == 1 for f in connected_faces)
+            end
         end
         
         @testset "Geometric Consistency" begin
-            nc = number_of_cells(embedded_mesh)
+            nc = number_of_cells(embedded_mesh_remove)
             # Test geometry computation
             for i in 1:nc
-                centroid, volume = Jutul.compute_centroid_and_measure(embedded_mesh, Cells(), i)
+                centroid, volume = Jutul.compute_centroid_and_measure(embedded_mesh_remove, Cells(), i)
                 centroid_p, area_p = Jutul.compute_centroid_and_measure(parent_mesh, Faces(), fracture_faces[i])
-                cell_normal = Jutul.EmbeddedMeshes.cell_normal(embedded_mesh, i)
+                cell_normal = Jutul.EmbeddedMeshes.cell_normal(embedded_mesh_remove, i)
                 face_normal = Jutul.face_normal(parent_mesh, fracture_faces[i], Faces())
                 @test all(isapprox.(centroid, centroid_p))
                 @test all(isapprox.(volume, area_p))

--- a/test/embedded_meshes.jl
+++ b/test/embedded_meshes.jl
@@ -53,15 +53,15 @@ using Jutul.EmbeddedMeshes
             @test embedded_mesh_remove isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh_remove.unstructured_mesh isa Jutul.UnstructuredMesh
             @test embedded_mesh_remove.intersection_neighbors isa Vector{Vector{Int}}
-            @test embedded_mesh_remove.intersection_boundary_faces isa Vector{Vector{Int}}
+            @test embedded_mesh_remove.intersection_edges isa Vector{Vector{Int}}
             @test embedded_mesh_remove.intersection_cells == Int[]
             @test embedded_mesh_star isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh_star.intersection_neighbors == embedded_mesh_remove.intersection_neighbors
-            @test embedded_mesh_star.intersection_boundary_faces == [Int[] for _ in embedded_mesh_star.intersection_neighbors]
+            @test all(!isempty, embedded_mesh_star.intersection_edges)
             @test embedded_mesh_star.intersection_cells == Int[]
             @test embedded_mesh_keep isa Jutul.EmbeddedMeshes.EmbeddedMesh
             @test embedded_mesh_keep.intersection_neighbors == embedded_mesh_remove.intersection_neighbors
-            @test embedded_mesh_keep.intersection_boundary_faces == [Int[] for _ in embedded_mesh_keep.intersection_neighbors]
+            @test all(!isempty, embedded_mesh_keep.intersection_edges)
             @test length(embedded_mesh_keep.intersection_cells) == length(embedded_mesh_keep.intersection_neighbors)
             
             # Test basic interface functions
@@ -87,7 +87,7 @@ using Jutul.EmbeddedMeshes
             @test length(umesh.faces.neighbors) == nf
             @test length(umesh.boundary_faces.neighbors) == nbf
             @test all(length.(embedded_mesh_remove.intersection_neighbors) .== 4)
-            @test all(length.(embedded_mesh_remove.intersection_boundary_faces) .== 4)
+            @test all(length.(embedded_mesh_remove.intersection_edges) .== 4)
 
             umesh_connected = embedded_mesh_star.unstructured_mesh
             @test all(length.(embedded_mesh_star.intersection_neighbors) .== 4)
@@ -105,7 +105,7 @@ using Jutul.EmbeddedMeshes
             end
 
             # Remove strategy should disconnect the intersection into boundary faces.
-            for (ix, ix_boundary_faces) in zip(embedded_mesh_remove.intersection_neighbors, embedded_mesh_remove.intersection_boundary_faces)
+            for (ix, ix_boundary_faces) in zip(embedded_mesh_remove.intersection_neighbors, embedded_mesh_remove.intersection_edges)
                 ix_set = Set(ix)
                 has_internal_ix_link = any(eachcol(neighbors)) do n
                     (n[1] in ix_set) && (n[2] in ix_set)


### PR DESCRIPTION
This pull request introduces a major refactor and extension of the `EmbeddedMesh` construction and intersection handling in the finite volume discretization framework. The core enhancement is the addition of flexible intersection strategies (`:remove`, `:star_delta`, and `:keep`), which allow precise control over how mesh intersections are represented and connected. The changes affect mesh construction, transmissibility computation, and the test suite, enabling more robust and varied modeling of embedded features.

Key changes include:

### EmbeddedMesh intersection strategy and data structure overhaul

* The `EmbeddedMesh` type now contains explicit fields for `parent_faces`, `intersection_neighbors`, `intersection_faces`, and `intersection_cells`, replacing the previous `intersections` field. This enables detailed tracking of intersection topology and supports multiple intersection handling strategies.
* The `EmbeddedMesh` constructor now accepts a new `intersection_strategy` keyword argument, supporting `:remove`, `:star_delta`, and `:keep` modes. The mesh construction pipeline and supporting functions (`make_mesh_from_faces`, `split_intersections`, and new helper `remap_intersection_edges`) have been refactored to implement these strategies, including the creation of intersection cells and appropriate edge/face mappings. [[1]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bR34-R53) [[2]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL46-R65) [[3]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL81-R152) [[4]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL147-R214) [[5]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL159-R237) [[6]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL169-R249) [[7]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL181-R307) [[8]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL206-R317) [[9]](diffhunk://#diff-70e5e739d8ceb144da74812ab4399fad0813c71848e00d98c54e2fe48cc7eb6bL243-R359)

### Finite volume transmissibility and geometry updates

* The `Jutul.compute_half_face_trans` function now handles intersection cells according to the selected strategy, including copying transmissibilities from neighbors for `:keep` mode. The function signature is updated to accept `aperture`, and logic is added to skip intersection cells during the main loop and process them separately. [[1]](diffhunk://#diff-a382f0761acb9687141efd993be6c61155e84afcb24cd782cf51dda47da9f36fL7-R12) [[2]](diffhunk://#diff-a382f0761acb9687141efd993be6c61155e84afcb24cd782cf51dda47da9f36fR45-R50) [[3]](diffhunk://#diff-a382f0761acb9687141efd993be6c61155e84afcb24cd782cf51dda47da9f36fR63-R87)
* The centroid and area computation for intersection cells in `Jutul.compute_centroid_and_measure` is updated to use the first face of the intersection, ensuring correct geometry for intersection cells.
* The `compute_face_trans_dfm` function now optionally applies intersection transmissibility corrections only when the `star_delta` strategy is active.

### Test suite enhancements

* The test suite is expanded to construct and verify `EmbeddedMesh` instances for all three intersection strategies. Tests are added to check the new data structures, the number of cells/faces, and the connectivity for each strategy, ensuring correctness and robustness of the new logic.