### PR TITLE
Transfer custom entities into DiscretizedDomain

### DIFF
--- a/src/core_types/core_types.jl
+++ b/src/core_types/core_types.jl
@@ -286,6 +286,9 @@ function SimulationModel(domain, system;
         end
     end
     domain = discretize_domain(domain, system; kwarg...)
+    if domain isa DiscretizedDomain && data_domain isa DataDomain
+        transfer_entities!(domain, data_domain)
+    end
     domain = transfer(context, domain)
     if !ismissing(plot_mesh)
         error("plot_mesh argument is deprecated.")

--- a/src/core_types/domains.jl
+++ b/src/core_types/domains.jl
@@ -69,6 +69,24 @@ function declare_entities(domain::DataDomain)
 end
 
 """
+    transfer_entities!(disc::DiscretizedDomain, data::DataDomain)
+
+Add any entities present in `data` but missing from `disc` into `disc.entities`.
+Entities already present must have matching counts.
+"""
+function transfer_entities!(disc::DiscretizedDomain, data::DataDomain)
+    for (entity, n) in data.entities
+        if haskey(disc.entities, entity)
+            disc_n = disc.entities[entity]
+            @assert disc_n == n "Entity $entity: DiscretizedDomain has count $disc_n but DataDomain has $n"
+        else
+            disc.entities[entity] = n
+        end
+    end
+    return disc
+end
+
+"""
     physical_representation(x::DataDomain)
 
 Get the underlying physical representation (domain or mesh) that is wrapped.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -132,6 +132,25 @@ end
         )
 end
 
+struct PropagateEntitiesTestTag <: JutulEntity end
+
+@testset "transfer_entities!" begin
+    g = CartesianMesh((2, 2))
+    d = DataDomain(g)
+    d.entities[PropagateEntitiesTestTag()] = 1
+    d[:tag_scalar, PropagateEntitiesTestTag()] = 3.14
+    disc = DiscretizedDomain(g)
+    @test !haskey(disc.entities, PropagateEntitiesTestTag())
+    Jutul.transfer_entities!(disc, d)
+    @test haskey(disc.entities, PropagateEntitiesTestTag())
+    @test disc.entities[PropagateEntitiesTestTag()] == 1
+    @test count_entities(disc, Cells()) == count_entities(d, Cells())
+    # SimulationModel propagates custom entities from DataDomain automatically
+    struct DummySys <: JutulSystem end
+    model = SimulationModel(d, DummySys())
+    @test haskey(model.domain.entities, PropagateEntitiesTestTag())
+end
+
 @testset "get_1d_interpolator" begin
     for constant_dx in [true, false, missing]
         # Test scalar interpolation


### PR DESCRIPTION
`SimulationModel `construction discretizes the domain, but any custom `JutulEntity `types registered on the `DataDomain `were silently dropped. This PR adds `transfer_entities!(disc, data)`, which copies entities present in a `DataDomain `but absent from the resulting `DiscretizedDomain`, and calls it automatically inside the `SimulationModel `constructor. A test is included.