### PR TITLE
Add states/reports kwargs to simulate! and initial_setup!

### DIFF
--- a/src/simulator/simulator.jl
+++ b/src/simulator/simulator.jl
@@ -154,13 +154,18 @@ simulate(sim::JutulSimulator, timesteps::JUTUL_TSTEP_VECTOR_TYPE; kwarg...) = si
         restart = nothing,
         state0 = nothing,
         parameters = nothing,
+        states = Vector{JUTUL_OUTPUT_TYPE}(),
+        reports = [],
         kwarg...
     )
 
 Non-allocating (or perhaps less allocating) version of [`simulate!`](@ref).
 
 # Arguments
-- `initialize=true`: Perform internal updates as if this is the first time 
+- `initialize=true`: Perform internal updates as if this is the first time
+- `states`, `reports`: Pre-allocated output containers. Defaults are fresh empty
+  vectors. Supply your own to retain partial output when `simulate!` throws
+  mid-loop (e.g. from a `post_ministep_hook`).
 
 See also [`simulate`](@ref) for additional supported input arguments.
 """
@@ -173,6 +178,8 @@ function simulate!(sim::JutulSimulator, timesteps::JUTUL_TSTEP_VECTOR_TYPE;
         parameters = nothing,
         forces_per_step = isa(forces, Vector),
         start_date = nothing,
+        states = Vector{JUTUL_OUTPUT_TYPE}(),
+        reports = [],
         kwarg...
     )
     if timesteps isa Real
@@ -207,7 +214,9 @@ function simulate!(sim::JutulSimulator, timesteps::JUTUL_TSTEP_VECTOR_TYPE;
         restart = restart,
         state0 = state0,
         parameters = parameters,
-        nsteps = no_steps
+        nsteps = no_steps,
+        states = states,
+        reports = reports
     )
     # Config options
     max_its = config[:max_nonlinear_iterations]
@@ -613,16 +622,20 @@ function initialize_before_first_timestep!(sim, first_dT; kwarg...)
     end
 end
 
-function initial_setup!(sim, config, timesteps; restart = nothing, parameters = nothing, state0 = nothing, nsteps = Inf)
+function initial_setup!(sim, config, timesteps;
+        restart = nothing,
+        parameters = nothing,
+        state0 = nothing,
+        nsteps = Inf,
+        states = Vector{JUTUL_OUTPUT_TYPE}(),
+        reports = []
+    )
     # Timing stuff
     set_global_timer!(config[:extra_timing])
     # Threading
     if Threads.nthreads() > 1
         PolyesterWeave.reset_workers!()
     end
-    # Set up storage
-    reports = []
-    states = Vector{JUTUL_OUTPUT_TYPE}()
     pth = config[:output_path]
     initialize_io(pth)
     has_restart = !(isnothing(restart) || restart === 0 || restart === 1 || restart == false)


### PR DESCRIPTION
Adds two optional kwargs to `simulate!` (and `initial_setup!`) so a caller can supply their own output containers:

```julia
simulate!(sim, dt;
    ...,
    states  = my_states,
    reports = my_reports,
)
```

Defaults are fresh empty vectors, matching prior behavior exactly. The point is the exception path: today `states` / `reports` are created inside `initial_setup!`, so if `simulate!` throws mid-loop — e.g. a user-supplied `post_ministep_hook` raises — the K already-committed report steps are lost when the local vectors go out of scope. With user-supplied containers, the appends already done by `store_output!` persist in the caller's vectors, and the caller can build a `SimResult` from them for partial-result preservation.

Motivating use case: we wrap `simulate!` with a wall-clock deadline that throws when the solver appears stuck in cut-retry. Currently a sample that converged 19 steps and got stuck on step 20 returns zero states; with this patch it returns the 19.

19 insertions, 6 deletions. No new behavior on the happy path; same identity-of-storage on the exception path.