### PR TITLE
DictOptimization: fix per-scalar limit lookup in optimizer_devectorize_scaler!

### DIFF
--- a/src/DictOptimization/optimization.jl
+++ b/src/DictOptimization/optimization.jl
@@ -288,8 +288,8 @@ function optimizer_devectorize_scaler!(X_new, X, i, pos, offsets, minlims, maxli
         N = offsets[i+1]-offsets[i]
         ind = pos+1:pos+N
         lim_bnds = group_limits(minlims, maxlims, ind)
-        for (i, ix) in enumerate(ind)
-            lim_val = scaler_limits(minlims, maxlims, i)
+        for ix in ind
+            lim_val = scaler_limits(minlims, maxlims, ix)
             bnds = LimitBounds(lim_val, lim_bnds)
             push!(X_new, undo_scaler(X[ix], bnds, stats, scaler))
         end

--- a/test/adjoints/basic_adjoint.jl
+++ b/test/adjoints/basic_adjoint.jl
@@ -300,7 +300,7 @@ import Jutul.DictOptimization as DictOptimization
 
     @test_throws "[\"scalar\"] has limit abs_min larger than initial value 3.0" DictOptimization.free_optimization_parameter!(dopt, "scalar", abs_min = 5.0, abs_max = 4.0)
     @test_throws "[\"scalar\"] has no feasible values for abs_min = 3.0 and abs_max = 3.0" DictOptimization.free_optimization_parameter!(dopt, "scalar", abs_min = 3.0, abs_max = 3.0)
-    @test_throws "[\"vector\"] has limit abs_min larger than initial value -1.0 in entry at CartesianIndex(2,)." DictOptimization.free_optimization_parameter!(dopt, "vector", abs_min = 0.0, abs_max = 4.0)
+    @test_throws "[\"vector\"] has limit abs_min larger than initial value -1.0 in entry at CartesianIndex(2" DictOptimization.free_optimization_parameter!(dopt, "vector", abs_min = 0.0, abs_max = 4.0)
 
     free_optimization_parameter!(dopt, "scalar", abs_min = -2.0, abs_max = 4.0)
     s = dopt.parameter_targets[["scalar"]]


### PR DESCRIPTION
This small fix seems correct to me, but I'm surprised it hasn't surfaced before, so worth having a separate look.

Claude:
The non-lumped branch used the loop-local index `i` (1..N within the current parameter) instead of the global index into the limits vectors when resolving per-scalar bounds for scalers such as `:linear_limits`. Any free parameter after the first in the optimization vector was descaled against the *first* parameter's box, corrupting its values (and every subsequent forward solve / gradient). Only surfaced with two or more scaled free parameters.